### PR TITLE
Backport Docker changes to Mac setup and a partial Linode StackScript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,4 @@ tmp/swap
 dgd
 websocket-to-tcp-tunnel
 orchil
+log/**/*.log

--- a/dev_scripts/docker/Dockerfile
+++ b/dev_scripts/docker/Dockerfile
@@ -1,0 +1,34 @@
+FROM debian:buster
+
+# Set up Apt Packages
+RUN apt-get update -y
+RUN apt-get upgrade -y
+RUN curl -sL https://deb.nodesource.com/setup_15.x | bash -
+RUN apt-get install nodejs npm -y
+RUN apt-get install sudo git nginx-full cron -y
+
+# Clone SkotOS
+RUN git clone https://github.com/ChatTheatre/SkotOS /var/skotos
+
+# Configure NGinX
+COPY skotos_game.conf /etc/nginx/sites-available/
+RUN ln -s /etc/nginx/sites-available/skotos_game.conf /etc/nginx/sites-enabled/skotos_game.conf
+RUN rm -f /etc/nginx/sites-enabled/default
+RUN nginx -s reload || nginx
+
+# Configure websocket-to-tcp-tunnel
+RUN mkdir -p /var/log/tunnel
+RUN git clone https://github.com/ChatTheatre/websocket-to-tcp-tunnel /usr/local/websocket-to-tcp-tunnel
+RUN cd /usr/local/websocket-to-tcp-tunnel && npm install
+RUN cd /usr/local/websocket-to-tcp-tunnel && chmod a+x *.sh
+
+COPY tunnel_config.json /usr/local/websocket-to-tcp-tunnel/config.json
+COPY crontab.txt /root/crontab.txt
+
+# Set up running the tunnel
+RUN /usr/local/websocket-to-tcp-tunnel/search-tunnel.sh
+RUN crontab /root/crontab.txt
+
+RUN mkdir -p /var/www/html
+RUN git clone https://github.com/ChatTheatre/orchil /var/www/html/client
+COPY profiles.js /var/www/html/client/profiles.js

--- a/dev_scripts/docker/Dockerfile
+++ b/dev_scripts/docker/Dockerfile
@@ -12,6 +12,9 @@ EXPOSE 10802
 # DGD HTTP port (direct)
 EXPOSE 10080
 
+# DGD TextIF port
+EXPOSE 10443
+
 # Future TODO: install supervisor package, run tunnels and DGD via supervisord in start_dgd_server.sh
 
 # Set up Apt Packages
@@ -38,7 +41,7 @@ RUN cd /var/dgd/src && make DEFINES='-DUINDEX_TYPE="unsigned int" -DUINDEX_MAX=U
 RUN git clone https://github.com/ChatTheatre/SkotOS /var/skotos
 COPY patch_devuserd.sh /root/patch_devuserd.sh
 RUN chmod +x /root/patch_devuserd.sh
-RUN bash /root/patch_devuserd.sh
+RUN cd /var/skotos && /root/patch_devuserd.sh
 
 # Configure NGinX
 COPY skotos_game.conf /etc/nginx/sites-available/skotos_game.conf

--- a/dev_scripts/docker/Dockerfile
+++ b/dev_scripts/docker/Dockerfile
@@ -1,12 +1,23 @@
 FROM debian:buster
 
-EXPOSE 8080
-EXPOSE 22
+# NGinX serving game client
+EXPOSE 10900
+
+# NGinX websocket port, forwarded to internal tunnel
+EXPOSE 10800
+
+# Tunnel-to-WOE Relay
+EXPOSE 10802
+
+# DGD HTTP port (direct)
+EXPOSE 10080
+
+# Future TODO: install supervisor package, run tunnels and DGD via supervisord in start_dgd_server.sh
 
 # Set up Apt Packages
 RUN apt-get update -y
 RUN apt-get upgrade -y
-RUN apt-get install sudo build-essential bison git nginx-full cron -y
+RUN apt-get install sudo build-essential bison git nginx-full -y
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
 RUN apt-get update -y
 RUN apt-get install nodejs npm -y
@@ -18,7 +29,6 @@ RUN cd /usr/local/websocket-to-tcp-tunnel && npm install
 RUN cd /usr/local/websocket-to-tcp-tunnel && chmod a+x *.sh
 
 COPY tunnel_config.json /usr/local/websocket-to-tcp-tunnel/config.json
-COPY crontab.txt /root/crontab.txt
 
 # Build DGD
 RUN git clone https://github.com/ChatTheatre/dgd /var/dgd
@@ -34,10 +44,6 @@ RUN bash /root/patch_devuserd.sh
 COPY skotos_game.conf /etc/nginx/sites-available/skotos_game.conf
 RUN ln -s /etc/nginx/sites-available/skotos_game.conf /etc/nginx/sites-enabled/skotos_game.conf
 RUN rm -f /etc/nginx/sites-enabled/default
-
-# Set up running the tunnel
-RUN /usr/local/websocket-to-tcp-tunnel/search-tunnel.sh
-RUN crontab /root/crontab.txt
 
 RUN mkdir -p /var/www/html
 RUN git clone https://github.com/ChatTheatre/orchil /var/www/html/client

--- a/dev_scripts/docker/Dockerfile
+++ b/dev_scripts/docker/Dockerfile
@@ -1,20 +1,15 @@
 FROM debian:buster
 
+EXPOSE 8080
+EXPOSE 22
+
 # Set up Apt Packages
 RUN apt-get update -y
 RUN apt-get upgrade -y
-RUN curl -sL https://deb.nodesource.com/setup_15.x | bash -
+RUN apt-get install sudo build-essential bison git nginx-full cron -y
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
+RUN apt-get update -y
 RUN apt-get install nodejs npm -y
-RUN apt-get install sudo git nginx-full cron -y
-
-# Clone SkotOS
-RUN git clone https://github.com/ChatTheatre/SkotOS /var/skotos
-
-# Configure NGinX
-COPY skotos_game.conf /etc/nginx/sites-available/
-RUN ln -s /etc/nginx/sites-available/skotos_game.conf /etc/nginx/sites-enabled/skotos_game.conf
-RUN rm -f /etc/nginx/sites-enabled/default
-RUN nginx -s reload || nginx
 
 # Configure websocket-to-tcp-tunnel
 RUN mkdir -p /var/log/tunnel
@@ -25,6 +20,21 @@ RUN cd /usr/local/websocket-to-tcp-tunnel && chmod a+x *.sh
 COPY tunnel_config.json /usr/local/websocket-to-tcp-tunnel/config.json
 COPY crontab.txt /root/crontab.txt
 
+# Build DGD
+RUN git clone https://github.com/ChatTheatre/dgd /var/dgd
+RUN cd /var/dgd/src && make DEFINES='-DUINDEX_TYPE="unsigned int" -DUINDEX_MAX=UINT_MAX -DEINDEX_TYPE="unsigned short" -DEINDEX_MAX=USHRT_MAX -DSSIZET_TYPE="unsigned int" -DSSIZET_MAX=1048576' install
+
+# Clone SkotOS
+RUN git clone https://github.com/ChatTheatre/SkotOS /var/skotos
+COPY patch_devuserd.sh /root/patch_devuserd.sh
+RUN chmod +x /root/patch_devuserd.sh
+RUN bash /root/patch_devuserd.sh
+
+# Configure NGinX
+COPY skotos_game.conf /etc/nginx/sites-available/skotos_game.conf
+RUN ln -s /etc/nginx/sites-available/skotos_game.conf /etc/nginx/sites-enabled/skotos_game.conf
+RUN rm -f /etc/nginx/sites-enabled/default
+
 # Set up running the tunnel
 RUN /usr/local/websocket-to-tcp-tunnel/search-tunnel.sh
 RUN crontab /root/crontab.txt
@@ -32,3 +42,8 @@ RUN crontab /root/crontab.txt
 RUN mkdir -p /var/www/html
 RUN git clone https://github.com/ChatTheatre/orchil /var/www/html/client
 COPY profiles.js /var/www/html/client/profiles.js
+
+# Configure SkotOS as "the app"
+COPY start_dgd_server.sh /var/start_dgd_server.sh
+RUN chmod +x /var/start_dgd_server.sh
+CMD cd /var && ./start_dgd_server.sh

--- a/dev_scripts/docker/Dockerfile
+++ b/dev_scripts/docker/Dockerfile
@@ -15,6 +15,12 @@ EXPOSE 10080
 # DGD TextIF port
 EXPOSE 10443
 
+# DGD telnet port
+EXPOSE 10098
+
+# DGD emergency binary port (admin-only)
+EXPOSE 10099
+
 # Future TODO: install supervisor package, run tunnels and DGD via supervisord in start_dgd_server.sh
 
 # Set up Apt Packages

--- a/dev_scripts/docker/PUSHING.txt
+++ b/dev_scripts/docker/PUSHING.txt
@@ -1,0 +1,15 @@
+# Creating and Pushing a Docker image to Docker Hub
+
+To build an image from Dockerfile, use the build script, or directly build:
+
+    docker build --no-cache -t noahgibbs/skotos .
+
+You'll also need to log in:
+
+    docker login --username=noahgibbs
+
+You should then be able to push to Docker Hub:
+
+   docker push noahgibbs/skotos
+
+Pushing will take significant time and a lot of bandwidth.

--- a/dev_scripts/docker/build.sh
+++ b/dev_scripts/docker/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker build --no-cache -t skotos .
+docker build --no-cache -t noahgibbs/skotos .

--- a/dev_scripts/docker/build.sh
+++ b/dev_scripts/docker/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker build --no-cache .
+docker build -t skotos .

--- a/dev_scripts/docker/build.sh
+++ b/dev_scripts/docker/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker build --no-cache .

--- a/dev_scripts/docker/build.sh
+++ b/dev_scripts/docker/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker build -t skotos .
+docker build --no-cache -t skotos .

--- a/dev_scripts/docker/crontab.txt
+++ b/dev_scripts/docker/crontab.txt
@@ -1,0 +1,2 @@
+@reboot /usr/local/websocket-to-tcp-tunnel/start-tunnel.sh
+* * * * * /usr/local/websocket-to-tcp-tunnel/search-tunnel.sh

--- a/dev_scripts/docker/crontab.txt
+++ b/dev_scripts/docker/crontab.txt
@@ -1,2 +1,0 @@
-@reboot /usr/local/websocket-to-tcp-tunnel/start-tunnel.sh
-* * * * * /usr/local/websocket-to-tcp-tunnel/search-tunnel.sh

--- a/dev_scripts/docker/patch_devuserd.sh
+++ b/dev_scripts/docker/patch_devuserd.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+set -x
+
+DEVUSERD=skoot/usr/System/sys/devuserd.c
+if grep -F "user_to_hash = ([ ])" $DEVUSERD
+then
+    # Unpatched - need to patch
+
+    #ruby -n -e 'puts $_.gsub("user_to_hash = ([ ])", "user_to_hash = ([ \"admin\": to_hex(hash_md5(\"adminpw\")), \"bobo\": to_hex(hash_md5(\"bobopw\")) ])")' < skoot/usr/System/sys/devuserd.c
+    sed 's/user_to_hash = (\[ \]);/user_to_hash = ([ "admin": to_hex(hash_md5("admin" + "adminpwd")), "bobo": to_hex(hash_md5("bobo" + "bobopwd")) ]);/g' < $DEVUSERD > /tmp/d2.c
+    mv /tmp/d2.c $DEVUSERD
+else
+    echo "DevUserD appears to be patched already. Moving on..."
+fi

--- a/dev_scripts/docker/profiles.js
+++ b/dev_scripts/docker/profiles.js
@@ -1,0 +1,15 @@
+"use strict";
+// orchil/profiles.js
+var profiles = {
+        "portal_gables":{
+                "method":   "websocket",
+                "protocol": "ws",
+                "server":   "localhost", //"chat.gables.chattheatre.com",
+                "port":      10800,
+                "woe_port":  10802,
+                "path":     "/gables",
+                "extra":    "",
+                "reports":   false,
+                "chars":    true,
+        }
+};

--- a/dev_scripts/docker/skotos_game.conf
+++ b/dev_scripts/docker/skotos_game.conf
@@ -5,27 +5,27 @@ map $http_upgrade $connection_upgrade {
         '' close;
         }
 
-upstream skotos {
-    server 127.0.0.1:8081;
+upstream gables {
+    server 127.0.0.1:10801;
 }
 
 server {
-    listen *:80 default;
-
-    root /var/www/html/client;
-    location / {
-        try_files $uri $uri/index.html $uri.html =404;
-    }
-}
-
-server {
-    listen *:8080;
+    listen *:10800;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    location /skotos {
-      proxy_pass http://skotos;
+    location /gables {
+      proxy_pass http://gables;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection $connection_upgrade;
+    }
+}
+
+server {
+    listen *:10900 default;
+
+    root /var/www/html/client;
+    location / {
+        try_files $uri $uri/ $uri/index.html $uri.html =404;
     }
 }

--- a/dev_scripts/docker/skotos_game.conf
+++ b/dev_scripts/docker/skotos_game.conf
@@ -1,0 +1,31 @@
+# skotos_game.conf
+
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+        '' close;
+        }
+
+upstream skotos {
+    server 127.0.0.1:8081;
+}
+
+server {
+    listen *:80 default;
+
+    root /var/www/html/client;
+    location / {
+        try_files $uri $uri/index.html $uri.html =404;
+    }
+}
+
+server {
+    listen *:8080;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    location /skotos {
+      proxy_pass http://skotos;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $connection_upgrade;
+    }
+}

--- a/dev_scripts/docker/start_dgd_server.sh
+++ b/dev_scripts/docker/start_dgd_server.sh
@@ -2,6 +2,15 @@
 
 set -e
 
+# TODO: run tunnels and DGD via supervisord (apt package name: supervisor)
+
+nginx || echo "NGinX already running?"
+nginx -t # Make sure NGinX config is correct
+nginx -s reload  # Make sure NGinX is responding
+
+# Make sure tunnels are running, at least initially
+/usr/local/websocket-to-tcp-tunnel/search-tunnel.sh
+
 cd /var/skotos
 
 if [ -f skotos.database ]

--- a/dev_scripts/docker/start_dgd_server.sh
+++ b/dev_scripts/docker/start_dgd_server.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+cd /var/skotos
+
+if [ -f skotos.database ]
+then
+    SKOTOS_CMD="/var/dgd/bin/dgd skotos.dgd skotos.database"
+else
+    SKOTOS_CMD="/var/dgd/bin/dgd skotos.dgd"
+fi
+
+$SKOTOS_CMD >/var/log/dgd_server.out 2>&1

--- a/dev_scripts/docker/tunnel_config.json
+++ b/dev_scripts/docker/tunnel_config.json
@@ -1,0 +1,22 @@
+{
+    "pidFileDirectory": "./",
+    "logDirectory": "/var/log/tunnel/",
+    "websocketHeartbeat": 30,
+    "shutdownDelay": 60,
+    "servers": [
+        {
+            "name": "skotosgame",
+            "listen": 10801,
+            "send": 10443,
+            "host": "localhost",
+            "sendTunnelInfo": false
+        },
+        {
+            "name": "skotos-tree-of-woe",
+            "listen": 10802,
+            "send": 10090,
+            "host": "localhost",
+            "sendTunnelInfo": false
+        }
+    ]
+}

--- a/dev_scripts/docker_mac_setup.sh
+++ b/dev_scripts/docker_mac_setup.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+
+# cd to the SkotOS root directory
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd $SCRIPT_DIR
+cd ..
+
+SKOTOS_ROOT="$(pwd)"
+
+if [ -f /Applications/Docker.app ]
+then
+    echo "Docker already installed, continuing..."
+else
+    echo "You'll need to install Docker Desktop. Please download the DMG file from this page, open it, and copy Docker into applications."
+    echo "        https://hub.docker.com/editions/community/docker-ce-desktop-mac/"
+
+    exit
+fi
+
+# Install prereqs: Homebrew
+which brew || /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+brew install telnet
+
+./dev_scripts/start_server.sh

--- a/dev_scripts/iterm_new.sh
+++ b/dev_scripts/iterm_new.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# I got this from a Gist on GitHub.
+
+#
+# Open new iTerm window from the command line
+#
+# Usage:
+#     iterm_new                   Opens the current directory in a new iTerm window
+#     iterm_new [PATH]            Open PATH in a new iTerm window
+#     iterm_new [CMD]             Open a new iTerm window and execute CMD
+#     iterm_new [PATH] [CMD] ...  You can prob'ly guess
+#
+# Example:
+#     iterm_new ~/Code/HelloWorld ./setup.sh
+#
+# References:
+#     iTerm AppleScript Examples:
+#     https://gitlab.com/gnachman/iterm2/wikis/Applescript
+# 
+# Credit:
+#     Inspired by tab.bash by @bobthecow
+#     link: https://gist.github.com/bobthecow/757788
+#
+
+# OSX only
+[ `uname -s` != "Darwin" ] && return
+
+function iterm () {
+    local cmd=""
+    local wd="$PWD"
+    local args="$@"
+
+    if [ -d "$1" ]; then
+        wd="$1"
+        args="${@:2}"
+    fi
+
+    if [ -n "$args" ]; then
+        # echo $args
+        cmd="; $args"
+    fi
+
+    osascript &>/dev/null <<EOF
+        tell application "iTerm"
+            activate
+            set term to (make new terminal)
+            tell term
+                launch session "Default Session"
+                tell the last session
+                    delay 1
+                    write text "cd $wd$cmd"
+                end
+            end
+        end tell
+EOF
+}
+iterm $@

--- a/dev_scripts/linode_stackscript.sh
+++ b/dev_scripts/linode_stackscript.sh
@@ -1,0 +1,295 @@
+#!/bin/bash
+
+# Script to stand up a production-flavoured SkotOS instance on Linode.
+
+# Based loosely on https://github.com/BlockchainCommons/Bitcoin-Standup-Scripts/blob/master/Scripts/LinodeStandUp.sh
+
+# Tested against: Debian 10
+
+# This block defines the variables the user of the script needs to input
+# when deploying using this script.
+#
+# <UDF name="hostname" label="Short Hostname" example="Example: my-awesome-game"/>
+# HOSTNAME=
+# <UDF name="fqdn" label="Fully Qualified Hostname" example="Example: my-awesome-game.my-domain.com"/>
+# FQDN=
+# <UDF name="userpassword" label="Deployment User Password" example="Password for the host deployment account." />
+# USERPASSWORD=
+# <UDF name="ssh_key" label="SSH Key" default="" example="SSH Key for automated logins to host's deployment account." optional="true" />
+# SSH_KEY=
+# <UDF name="skotosgiturl" label="Skotos Git URL" default="https://github.com/ChatTheatre/SkotOS" example="SkotOS Git URL to clone for your game." optional="false" />
+# SKOTOS_GIT_URL=
+
+
+
+# Some differences from full real SkotOS setup:
+#
+# 1. No IP address whitelisting for SSH
+# 2. No DNS setup with multiple names - one IP address, one domain name, one host
+# 3. No hosting multiple games per host
+
+set -e  # Fail on error
+
+# Force check for root, if you are not logged in as root then the script will not execute
+if ! [ "$(id -u)" = 0 ]
+then
+  echo "$0 - You need to be logged in as root!"
+  exit 1
+fi
+
+cd /
+
+# Output stdout and stderr to ~root files
+exec > >(tee -a /root/standup.log) 2> >(tee -a /root/standup.log /root/standup.err >&2)
+
+####
+# 1. Update Hostname
+####
+
+echo $HOSTNAME > /etc/hostname
+/bin/hostname $HOSTNAME
+
+# Set the variable $IPADDR to the IP address the new Linode receives.
+IPADDR=`hostname -I | awk '{print $1}'`
+
+echo "$0 - Set hostname as $FQDN ($IPADDR)"
+echo "$0 - TODO: Put $FQDN with IP $IPADDR in your main DNS file."
+
+# Add localhost aliases
+
+echo "127.0.0.1    localhost" > /etc/hosts
+echo "127.0.1.1 $FQDN $HOSTNAME" >> /etc/hosts
+
+echo "$0 - Set localhost"
+
+####
+# 2. Bring Debian Up To Date
+####
+
+echo "$0 - Starting Debian updates; this will take a while!"
+
+# Make sure all packages are up-to-date
+apt-get update -y
+apt-get upgrade -y
+apt-get dist-upgrade -y
+
+# Set system to automatically update
+echo "unattended-upgrades unattended-upgrades/enable_auto_updates boolean true" | debconf-set-selections
+apt-get -y install unattended-upgrades
+
+echo "$0 - Updated Debian Packages"
+
+# get uncomplicated firewall and deny all incoming connections except SSH
+#apt-get install ufw -y
+#ufw allow ssh
+#ufw enable
+
+####
+# 3. Set Up Initial User
+####
+
+# Create "skotos" user with optional password and give them sudo capability
+/usr/sbin/useradd -m -p `perl -e 'printf("%s\n",crypt($ARGV[0],"password"))' "$USERPASSWORD"` -g sudo -s /bin/bash skotos || echo "Skotos user already exists?"
+/usr/sbin/adduser skotos sudo
+
+echo "$0 - Setup skotos with sudo access."
+
+# Setup SSH Key if the user added one as an argument
+if [ -n "$SSH_KEY" ]
+then
+   mkdir ~skotos/.ssh
+   echo "$SSH_KEY" >> ~skotos/.ssh/authorized_keys
+   chown -R skotos ~skotos/.ssh
+
+   echo "$0 - Added .ssh key to skotos."
+fi
+
+####
+# 4. Install Dependencies
+####
+
+apt-get install git nginx-full -y
+
+# Websocket-to-tcp-tunnel requirements
+curl -sL https://deb.nodesource.com/setup_9.x | bash -
+apt install nodejs npm -y
+
+# Thin-auth requirements
+# apt-get install mariadb-server libapache2-mod-php php php-mysql -y
+
+####
+# 5. Set up Directories, Groups and Ownership
+####
+
+# A nod to local development on the Linode
+if [ -d /var/skotos ]
+then
+    pushd /var/skotos
+    git pull
+    popd
+else
+    git clone ${SKOTOS_GIT_URL} /var/skotos
+fi
+
+groupadd skotos || echo "Skotos group already exists"
+chgrp -R skotos /var/skotos
+chmod -R g+w /var/skotos
+
+rm -f ~skotos/crontab.txt
+touch ~skotos/crontab.txt
+chown -R skotos.skotos ~skotos/
+
+####
+# 6. Set up NGinX
+####
+
+cat >/etc/nginx/sites-available/skotos_game.conf <<EndOfMessage
+# skotos_game.conf
+
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+        '' close;
+        }
+
+upstream skotos {
+    server 127.0.0.1:8081;
+}
+
+server {
+    listen *:80 default;
+
+    root /var/www/html/client;
+    location / {
+        try_files $uri $uri/index.html $uri.html =404;
+    }
+}
+
+server {
+    listen *:8080;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    location /skotos {
+      proxy_pass http://skotos;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $connection_upgrade;
+    }
+}
+EndOfMessage
+
+rm -f /etc/nginx/sites-enabled/default
+
+nginx -t  # Verify everything parses correctly
+nginx -s reload
+
+####
+# 7. Set up Tunnel
+####
+
+mkdir -p /var/log/tunnel
+chown -R skotos.skotos /var/log/tunnel
+
+if [ -d /usr/local/websocket-to-tcp-tunnel ]
+then
+    pushd /usr/local/websocket-to-tcp-tunnel
+    git pull
+    popd
+else
+    git clone https://github.com/ChatTheatre/websocket-to-tcp-tunnel /usr/local/websocket-to-tcp-tunnel
+fi
+chown -R skotos.skotos /usr/local/websocket-to-tcp-tunnel
+
+pushd /usr/local/websocket-to-tcp-tunnel/
+npm install
+chmod a+x *.sh  # Can remove?
+popd
+
+cat >/usr/local/websocket-to-tcp-tunnel/config.json <<EndOfMessage
+{
+    "pidFileDirectory": "./",
+    "logDirectory": "/var/log/tunnel/",
+    "websocketHeartbeat": 30,
+    "shutdownDelay": 60,
+    "servers": [
+        {
+            "name": "skotosgame",
+            "listen": 10801,
+            "send": 10443,
+            "host": "localhost",
+            "sendTunnelInfo": false
+        },
+        {
+            "name": "skotos-tree-of-woe",
+            "listen": 10802,
+            "send": 10090,
+            "host": "localhost",
+            "sendTunnelInfo": false
+        }
+    ]
+}
+EndOfMessage
+
+sudo -u skotos /usr/local/websocket-to-tcp-tunnel/search-tunnel.sh
+cat >>~skotos/crontab.txt <<EndOfMessage
+@reboot /usr/local/websocket-to-tcp-tunnel/start-tunnel.sh
+* * * * * /usr/local/websocket-to-tcp-tunnel/search-tunnel.sh
+EndOfMessage
+crontab -u skotos ~skotos/crontab.txt
+
+####
+# 8. Set up Orchil
+####
+
+mkdir -p /var/www/html
+git clone https://github.com/ChatTheatre/orchil /var/www/html/client
+
+cat >>/var/www/html/client/profiles.js <<EndOfMessage
+"use strict";
+// orchil/profiles.js
+var profiles = {
+        "portal_gables":{
+                "method":   "websocket",
+                "protocol": "ws",
+                "server":   "localhost", //"chat.gables.chattheatre.com",
+                "port":      10800,
+                "woe_port":  10802,
+                "path":     "/gables",
+                "extra":    "",
+                "reports":   false,
+                "chars":    true,
+        }
+};
+EndOfMessage
+
+#####
+## 25. Set up Thin-Auth
+#####
+#
+# For thin-auth, add UDF variables for DBPASSWORD and PAYPALACCOUNT, plus
+# all the game-specific stuff including your logo, etc. Hard to say if those
+# could be UDF variables or if they need to be a different fork of thin-auth.
+#
+## thin-auth provides a SkotOS UserDB and full authentication facilities.
+## It is normally prod-only, and *must* be installed into /var/www/html/user
+#git clone https://github.com/ChatTheatre/thin-auth /var/www/html/user
+#cp /var/www/html/user/config/database.json-SAMPLE /var/www/html/user/config/database.json
+#cp /var/www/html/user/config/financial.json-SAMPLE /var/www/html/user/config/financial.json
+#cp /var/www/html/user/config/general.json-SAMPLE /var/www/html/user/config/general.json
+#cp /var/www/html/user/config/server.json-SAMPLE /var/www/html/user/config/server.json
+
+####
+# See Also
+####
+
+# "Setting Up a SkotOS Host": https://hackmd.io/L_6wWAXVRamgCWFPG9SqTw
+# https://github.com/ChatTheatre/thin-auth/blob/master/README.md
+# https://github.com/ChatTheatre/orchil
+
+####
+# 754. Stuff that isn't done yet
+####
+
+# * UFW setup
+# * Thin-Auth, including configuring its JSON files and its assets, game name, etc.
+# * Asset server for images, etc.
+# * Backups of any kind

--- a/dev_scripts/mac_setup.sh
+++ b/dev_scripts/mac_setup.sh
@@ -18,6 +18,16 @@ else
     false
 fi
 
+if [ -f /Applications/Docker.app ]
+then
+    echo "Docker already installed, continuing..."
+else
+    echo "You'll need to install Docker Desktop. Please download the DMG file from this page, open it, and copy Docker into applications."
+    echo "        https://hub.docker.com/editions/community/docker-ce-desktop-mac/"
+
+    exit
+fi
+
 # Patch SkotOS devuserd.c to add a dev user...
 
 DEVUSERD=skoot/usr/System/sys/devuserd.c
@@ -40,8 +50,11 @@ fi
 # Install prereqs: Homebrew
 which brew || /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 which git || brew install git
+brew upgrade git
 which npm || brew install npm
+brew upgrade npm
 which nginx || brew install nginx
+brew upgrade nginx
 
 if [ -f ~/.ssh/id_rsa.pub ]
 then

--- a/dev_scripts/mac_setup.sh
+++ b/dev_scripts/mac_setup.sh
@@ -9,15 +9,6 @@ cd ..
 
 SKOTOS_ROOT="$(pwd)"
 
-DGD_PID=$(ps aux | grep "dgd ./skotos.dgd" | grep -v grep | cut -c 14-25)
-if [ -z "$DGD_PID" ]
-then
-    echo "DGD does not appear to be running. Good."
-else
-    echo "DGD appears to be running SkotOS already with PID ${DGD_PID}. Shut down this copy of DGD before messing with the install."
-    false
-fi
-
 if [ -f /Applications/Docker.app ]
 then
     echo "Docker already installed, continuing..."
@@ -28,109 +19,8 @@ else
     exit
 fi
 
-# Patch SkotOS devuserd.c to add a dev user...
-
-DEVUSERD=skoot/usr/System/sys/devuserd.c
-if grep -F "user_to_hash = ([ ])" $DEVUSERD
-then
-    # Unpatched - need to patch
-
-    #ruby -n -e 'puts $_.gsub("user_to_hash = ([ ])", "user_to_hash = ([ \"admin\": to_hex(hash_md5(\"adminpw\")), \"bobo\": to_hex(hash_md5(\"bobopw\")) ])")' < skoot/usr/System/sys/devuserd.c
-    sed 's/user_to_hash = (\[ \]);/user_to_hash = ([ "admin": to_hex(hash_md5("admin" + "adminpwd")), "bobo": to_hex(hash_md5("bobo" + "bobopwd")) ]);/g' < $DEVUSERD > /tmp/d2.c
-    mv /tmp/d2.c $DEVUSERD
-else
-    echo "DevUserD appears to be patched already. Moving on..."
-fi
-
-# This script intends to set up your Mac for SkotOS development. It's as useful to read through
-# as to actually run. It should be runnable, especially on the first invocation.
-
-# It should run from the SkotOS root directory.
-
 # Install prereqs: Homebrew
 which brew || /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
-which git || brew install git
-brew upgrade git
-which npm || brew install npm
-brew upgrade npm
-which nginx || brew install nginx
-brew upgrade nginx
-
-if [ -f ~/.ssh/id_rsa.pub ]
-then
-    echo "Yes, you have an ~/.ssh/id_rsa.pub"
-else
-    # Generate the key and add it to the Mac keychain
-    echo "You have no RSA public key. You'll need to create one and register it with GitHub! I recommend an empty passphrase for convenience."
-    ssh-keygen -t rsa -f ~/.ssh/id_rsa
-    ssh-add -K ~/.ssh/id_rsa
-fi
-
-if git clone git@github.com:noahgibbs/env_mem.git /tmp/env_mem
-then
-    rm -rf /tmp/env_mem
-    echo "Git clone succeeded - you can clone repos from GitHub."
-else
-    echo "You can't check out a repo on GitHub. That probably means you need to register your SSH key with GitHub. Please check https://github.com/settings/keys and add ~/.ssh/id_rsa.pub so that you can check out repositories."
-    false  # Script will exit with error due to "set -e" above
-fi
-
-# Set up DGD
-if [ -d dgd ]
-then
-    echo "DGD Exists"
-    pushd dgd
-    git pull
-    popd
-else
-    echo "Cloning DGD"
-    git clone git@github.com:ChatTheatre/dgd.git dgd
-fi
-
-pushd dgd/src
-make DEFINES='-DUINDEX_TYPE="unsigned int" -DUINDEX_MAX=UINT_MAX -DEINDEX_TYPE="unsigned short" -DEINDEX_MAX=USHRT_MAX -DSSIZET_TYPE="unsigned int" -DSSIZET_MAX=1048576' install
-popd
-
-# Clone other ChatTheatre repos
-
-if [ -d orchil ]
-then
-    echo "Orchil exists, pulling..."
-    pushd orchil
-    git pull
-    popd
-else
-    echo "Cloning Orchil"
-    git clone git@github.com:ChatTheatre/orchil.git orchil
-fi
-
-if [ -d websocket-to-tcp-tunnel ]
-then
-    echo "Tunnel exists"
-    pushd websocket-to-tcp-tunnel
-    git pull
-    popd
-else
-    echo "Cloning Tunnel (websocket-to-tcp-tunnel)"
-    git clone git@github.com:ChatTheatre/websocket-to-tcp-tunnel.git websocket-to-tcp-tunnel
-fi
-
-pushd websocket-to-tcp-tunnel
-npm install
-popd
-
-echo "Copying Orchil config file..."
-cp dev_scripts/orchil_profiles.js orchil/profiles.js
-
-echo "NGinX configuration..."
-# TODO: don't blindly copy and modify this every time
-NG_CONF=/usr/local/etc/nginx/servers/skotos_dev_nginx.conf
-mkdir -p /usr/local/etc/nginx/servers/
-sed "s:%SKOTOS_ROOT_LOCATION%:${SKOTOS_ROOT}/orchil:" <dev_scripts/dev_nginx.conf >$NG_CONF
-
-echo "Testing that NGinX config will load... (enter admin password if needed by sudo)"
-sudo nginx -t
+brew install telnet
 
 ./dev_scripts/start_server.sh
-
-#cat dev_scripts/post_install_instructions.txt

--- a/dev_scripts/mac_setup.sh
+++ b/dev_scripts/mac_setup.sh
@@ -9,18 +9,115 @@ cd ..
 
 SKOTOS_ROOT="$(pwd)"
 
-if [ -f /Applications/Docker.app ]
+DGD_PID=$(ps aux | grep "dgd ./skotos.dgd" | grep -v grep | cut -c 14-25)
+if [ -z "$DGD_PID" ]
 then
-    echo "Docker already installed, continuing..."
+    echo "DGD does not appear to be running. Good."
 else
-    echo "You'll need to install Docker Desktop. Please download the DMG file from this page, open it, and copy Docker into applications."
-    echo "        https://hub.docker.com/editions/community/docker-ce-desktop-mac/"
-
-    exit
+    echo "DGD appears to be running SkotOS already with PID ${DGD_PID}. Shut down this copy of DGD before messing with the install."
+    false
 fi
+
+# Patch SkotOS devuserd.c to add a dev user...
+
+DEVUSERD=skoot/usr/System/sys/devuserd.c
+if grep -F "user_to_hash = ([ ])" $DEVUSERD
+then
+    # Unpatched - need to patch
+
+    #ruby -n -e 'puts $_.gsub("user_to_hash = ([ ])", "user_to_hash = ([ \"admin\": to_hex(hash_md5(\"adminpw\")), \"bobo\": to_hex(hash_md5(\"bobopw\")) ])")' < skoot/usr/System/sys/devuserd.c
+    sed 's/user_to_hash = (\[ \]);/user_to_hash = ([ "admin": to_hex(hash_md5("admin" + "adminpwd")), "bobo": to_hex(hash_md5("bobo" + "bobopwd")) ]);/g' < $DEVUSERD > /tmp/d2.c
+    mv /tmp/d2.c $DEVUSERD
+else
+    echo "DevUserD appears to be patched already. Moving on..."
+fi
+
+# This script intends to set up your Mac for SkotOS development. It's as useful to read through
+# as to actually run. It should be runnable, especially on the first invocation.
+
+# It should run from the SkotOS root directory.
 
 # Install prereqs: Homebrew
 which brew || /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
-brew install telnet
+which git || brew install git
+which npm || brew install npm
+which nginx || brew install nginx
+
+if [ -f ~/.ssh/id_rsa.pub ]
+then
+    echo "Yes, you have an ~/.ssh/id_rsa.pub"
+else
+    # Generate the key and add it to the Mac keychain
+    echo "You have no RSA public key. You'll need to create one and register it with GitHub! I recommend an empty passphrase for convenience."
+    ssh-keygen -t rsa -f ~/.ssh/id_rsa
+    ssh-add -K ~/.ssh/id_rsa
+fi
+
+if git clone git@github.com:noahgibbs/env_mem.git /tmp/env_mem
+then
+    rm -rf /tmp/env_mem
+    echo "Git clone succeeded - you can clone repos from GitHub."
+else
+    echo "You can't check out a repo on GitHub. That probably means you need to register your SSH key with GitHub. Please check https://github.com/settings/keys and add ~/.ssh/id_rsa.pub so that you can check out repositories."
+    false  # Script will exit with error due to "set -e" above
+fi
+
+# Set up DGD
+if [ -d dgd ]
+then
+    echo "DGD Exists"
+    pushd dgd
+    git pull
+    popd
+else
+    echo "Cloning DGD"
+    git clone git@github.com:ChatTheatre/dgd.git dgd
+fi
+
+pushd dgd/src
+make DEFINES='-DUINDEX_TYPE="unsigned int" -DUINDEX_MAX=UINT_MAX -DEINDEX_TYPE="unsigned short" -DEINDEX_MAX=USHRT_MAX -DSSIZET_TYPE="unsigned int" -DSSIZET_MAX=1048576' install
+popd
+
+# Clone other ChatTheatre repos
+
+if [ -d orchil ]
+then
+    echo "Orchil exists, pulling..."
+    pushd orchil
+    git pull
+    popd
+else
+    echo "Cloning Orchil"
+    git clone git@github.com:ChatTheatre/orchil.git orchil
+fi
+
+if [ -d websocket-to-tcp-tunnel ]
+then
+    echo "Tunnel exists"
+    pushd websocket-to-tcp-tunnel
+    git pull
+    popd
+else
+    echo "Cloning Tunnel (websocket-to-tcp-tunnel)"
+    git clone git@github.com:ChatTheatre/websocket-to-tcp-tunnel.git websocket-to-tcp-tunnel
+fi
+
+pushd websocket-to-tcp-tunnel
+npm install
+popd
+
+echo "Copying Orchil config file..."
+cp dev_scripts/orchil_profiles.js orchil/profiles.js
+
+echo "NGinX configuration..."
+# TODO: don't blindly copy and modify this every time
+NG_CONF=/usr/local/etc/nginx/servers/skotos_dev_nginx.conf
+mkdir -p /usr/local/etc/nginx/servers/
+sed "s:%SKOTOS_ROOT_LOCATION%:${SKOTOS_ROOT}/orchil:" <dev_scripts/dev_nginx.conf >$NG_CONF
+
+echo "Testing that NGinX config will load... (enter admin password if needed by sudo)"
+sudo nginx -t
 
 ./dev_scripts/start_server.sh
+
+#cat dev_scripts/post_install_instructions.txt

--- a/dev_scripts/post_install_instructions.txt
+++ b/dev_scripts/post_install_instructions.txt
@@ -4,12 +4,21 @@ To log in as a developer: telnet localhost 10098
 
 To create a new chat character: point your browser at http://localhost:10080/SAM/Prop/Theatre:Web:Theatre/Index
 
-To log in directly: point your web browser at http://localhost:10900/gables/gables.htm
+To log in directly when you already have a character: point your web browser at http://localhost:10900/gables/gables.htm
 
 By default, the setup script gave you an admin user with password "adminpwd" and a user named "bobo" with password "bobopwd". You can change these...
+
+You will need to type your character name into the pop-up and then *again* into the browser terminal. Sorry :-(
+
+After the first (very long) time you run SkotOS, it should create a state file in the container. Later boot-ups should be much faster unless the whole Docker container is destroyed.
 
 See https://ChatTheatre.github.io/SkotOS-Doc/setup.html for more details on the setup.
 
 In some terminal programs, this script just opened a bunch of terminal tabs like the DGD error log. If you can't find the terminal you ran this from, it's probably hidden by new tabs.
+
+### Untested and Upcoming
+
+SkotOS's builder interface:
+http://localhost:10900/gables/TreeOfWoe.html
 
 =========================================

--- a/dev_scripts/post_install_instructions.txt
+++ b/dev_scripts/post_install_instructions.txt
@@ -4,7 +4,7 @@ To log in as a developer: telnet localhost 10098
 
 To create a new chat character: point your browser at http://localhost:10080/SAM/Prop/Theatre:Web:Theatre/Index
 
-To log in directly when you already have a character: point your web browser at http://localhost:10900/gables/gables.htm
+To log in directly when you already have a character: point your web browser at http://localhost:10900/gables/gables.htm?charName=ignored
 
 By default, the setup script gave you an admin user with password "adminpwd" and a user named "bobo" with password "bobopwd". You can change these...
 

--- a/dev_scripts/post_install_instructions.txt
+++ b/dev_scripts/post_install_instructions.txt
@@ -1,13 +1,15 @@
 =========================================
 
-For the web client: point your web browser at http://localhost:10900/gables/gables.htm
-
 To log in as a developer: telnet localhost 10098
 
-For the outer "create a body" view: point your browser at http://localhost:10080/SAM/Prop/Theatre:Web:Theatre/Index
+To create a new chat character: point your browser at http://localhost:10080/SAM/Prop/Theatre:Web:Theatre/Index
+
+To log in directly: point your web browser at http://localhost:10900/gables/gables.htm
 
 By default, the setup script gave you an admin user with password "adminpwd" and a user named "bobo" with password "bobopwd". You can change these...
 
-See https://ChatTheatre.github.io/SkotOS-Doc/setup.html for more details on all of this!
+See https://ChatTheatre.github.io/SkotOS-Doc/setup.html for more details on the setup.
+
+In some terminal programs, this script just opened a bunch of terminal tabs like the DGD error log. If you can't find the terminal you ran this from, it's probably hidden by new tabs.
 
 =========================================

--- a/dev_scripts/show_dgd_logs.sh
+++ b/dev_scripts/show_dgd_logs.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd $SCRIPT_DIR
+cd ..
+
+tail -f $(pwd)/log/dgd_server.out

--- a/dev_scripts/show_post_install_instructions.sh
+++ b/dev_scripts/show_post_install_instructions.sh
@@ -2,4 +2,9 @@
 
 set -e
 
+# cd to the SkotOS root directory
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd $SCRIPT_DIR
+cd ..
+
 cat dev_scripts/post_install_instructions.txt

--- a/dev_scripts/show_post_install_instructions.sh
+++ b/dev_scripts/show_post_install_instructions.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+cat dev_scripts/post_install_instructions.txt

--- a/dev_scripts/stackscript/linode_stackscript.sh
+++ b/dev_scripts/stackscript/linode_stackscript.sh
@@ -31,6 +31,7 @@
 # 3. No hosting multiple games per host
 
 set -e  # Fail on error
+set -x
 
 # Force check for root, if you are not logged in as root then the script will not execute
 if ! [ "$(id -u)" = 0 ]
@@ -124,15 +125,10 @@ apt install nodejs npm -y
 ####
 
 groupadd skotos || echo "Skotos group already exists"
-chgrp -R skotos /var/skotos
-chmod -R g+w /var/skotos
 
 rm -f ~skotos/crontab.txt
 touch ~skotos/crontab.txt
 chown -R skotos.skotos ~skotos/
-
-mkdir /var/log
-chown -R skotos.skotos /var/log
 
 ####
 # Set up SkotOS and DGD
@@ -146,6 +142,8 @@ then
     popd
 else
     git clone ${SKOTOS_GIT_URL} /var/skotos
+    chgrp -R skotos /var/skotos
+    chmod -R g+w /var/skotos
 fi
 
 # A nod to local development on the Linode

--- a/dev_scripts/stackscript/linode_stackscript.sh
+++ b/dev_scripts/stackscript/linode_stackscript.sh
@@ -19,8 +19,8 @@
 # SSH_KEY=
 # <UDF name="skotosgiturl" label="Skotos Git URL" default="https://github.com/ChatTheatre/SkotOS" example="SkotOS Git URL to clone for your game." optional="false" />
 # SKOTOS_GIT_URL=
-# <UDF name="skotosdgdurl" label="Skotos DGD URL" default="https://github.com/ChatTheatre/dgd" example="SkotOS DGD URL to clone for your game." optional="false" />
-# SKOTOS_DGD_URL=
+# <UDF name="dgdgiturl" label="Skotos DGD URL" default="https://github.com/ChatTheatre/dgd" example="SkotOS DGD URL to clone for your game." optional="false" />
+# DGD_GIT_URL=
 
 
 
@@ -141,7 +141,8 @@ then
     git pull
     popd
 else
-    git clone ${SKOTOS_GIT_URL} /var/skotos
+    #git clone ${SKOTOS_GIT_URL} /var/skotos
+    git clone https://github.com/ChatTheatre/SkotOS /var/skotos
     chgrp -R skotos /var/skotos
     chmod -R g+w /var/skotos
 fi
@@ -153,6 +154,7 @@ then
     git pull
     popd
 else
+    #git clone ${DGD_GIT_URL} /var/dgd
     git clone https://github.com/ChatTheatre/dgd /var/dgd
 fi
 

--- a/dev_scripts/stackscript/linode_stackscript.sh
+++ b/dev_scripts/stackscript/linode_stackscript.sh
@@ -19,6 +19,8 @@
 # SSH_KEY=
 # <UDF name="skotosgiturl" label="Skotos Git URL" default="https://github.com/ChatTheatre/SkotOS" example="SkotOS Git URL to clone for your game." optional="false" />
 # SKOTOS_GIT_URL=
+# <UDF name="skotosdgdurl" label="Skotos DGD URL" default="https://github.com/ChatTheatre/dgd" example="SkotOS DGD URL to clone for your game." optional="false" />
+# SKOTOS_DGD_URL=
 
 
 
@@ -146,8 +148,22 @@ else
     git clone ${SKOTOS_GIT_URL} /var/skotos
 fi
 
+# A nod to local development on the Linode
+if [ -d "/var/dgd" ]
+then
+    pushd /var/dgd
+    git pull
+    popd
+else
+    git clone ${SKOTOS_DGD_URL} /var/dgd
+fi
+
+pushd /var/dgd/src
+make DEFINES='-DUINDEX_TYPE="unsigned int" -DUINDEX_MAX=UINT_MAX -DEINDEX_TYPE="unsigned short" -DEINDEX_MAX=USHRT_MAX -DSSIZET_TYPE="unsigned int" -DSSIZET_MAX=1048576' install
+popd
+
 cat >>~skotos/crontab.txt <<EndOfMessage
-@reboot cd /var/skotos/dev_scripts/stackscript/start_dgd_server.sh
+@reboot /var/skotos/dev_scripts/stackscript/start_dgd_server.sh &
 EndOfMessage
 
 ####

--- a/dev_scripts/stackscript/linode_stackscript.sh
+++ b/dev_scripts/stackscript/linode_stackscript.sh
@@ -19,6 +19,8 @@
 # SSH_KEY=
 # <UDF name="skotosgiturl" label="Skotos Git URL" default="https://github.com/ChatTheatre/SkotOS" example="SkotOS Git URL to clone for your game." optional="false" />
 # SKOTOS_GIT_URL=
+# <UDF name="skotosdgdurl" label="Skotos DGD URL" default="https://github.com/ChatTheatre/dgd" example="SkotOS DGD URL to clone for your game." optional="false" />
+# SKOTOS_DGD_URL=
 
 
 

--- a/dev_scripts/stackscript/linode_stackscript.sh
+++ b/dev_scripts/stackscript/linode_stackscript.sh
@@ -19,8 +19,6 @@
 # SSH_KEY=
 # <UDF name="skotosgiturl" label="Skotos Git URL" default="https://github.com/ChatTheatre/SkotOS" example="SkotOS Git URL to clone for your game." optional="false" />
 # SKOTOS_GIT_URL=
-# <UDF name="skotosdgdurl" label="Skotos DGD URL" default="https://github.com/ChatTheatre/dgd" example="SkotOS DGD URL to clone for your game." optional="false" />
-# SKOTOS_DGD_URL=
 
 
 
@@ -153,7 +151,7 @@ then
     git pull
     popd
 else
-    git clone ${SKOTOS_DGD_URL} /var/dgd
+    git clone https://github.com/ChatTheatre/dgd /var/dgd
 fi
 
 pushd /var/dgd/src

--- a/dev_scripts/stackscript/start_dgd_server.sh
+++ b/dev_scripts/stackscript/start_dgd_server.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+cd /var/skotos
+
+if [ -f skotos.database ]
+then
+    SKOTOS_CMD="/var/dgd/bin/dgd skotos.dgd skotos.database"
+else
+    SKOTOS_CMD="/var/dgd/bin/dgd skotos.dgd"
+fi
+
+$SKOTOS_CMD >/var/log/dgd_server.out 2>&1

--- a/dev_scripts/start_server.sh
+++ b/dev_scripts/start_server.sh
@@ -7,13 +7,16 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd $SCRIPT_DIR
 cd ..
 
+DOCKER_TAG="noahgibbs/skotos:earliest"
+
 if (docker ps -a | grep sk)
 then
     # Restart the stopped container, if it's stopped
     docker start sk || echo "Maybe the Docker container is already running?"
 else
     # Create a new container
-    docker run -p 10800:10800 -p 10900:10900 -p 10802:10802 -p 10080:10080 -p 10443:10443 --mount type=bind,src="$(pwd)/log",target="/var/log" --detach --name sk skotos
+    docker pull noahgibbs/skotos
+    docker run -p 10800:10800 -p 10900:10900 -p 10802:10802 -p 10080:10080 -p 10443:10443 -p 10098:10098 -p 10099:10099 --mount type=bind,src="$(pwd)/log",target="/var/log" --detach --name sk noahgibbs/skotos
 fi
 docker ps -a | grep sk && echo "You are already running a Docker container! Run stop_server.sh to remove it."
 
@@ -22,7 +25,7 @@ docker ps -a | grep sk && echo "You are already running a Docker container! Run 
 #    https://github.com/ohmyzsh/ohmyzsh/blob/master/plugins/osx/osx.plugin.zsh
 
 # Open iTerm/terminal window showing DGD process log
-open -a $TERM_PROGRAM dev_scripts/show_dgd_logs.sh
+open -a Terminal -n dev_scripts/show_dgd_logs.sh
 
 # Wait until SkotOS is booted and responsive
 while true
@@ -30,15 +33,12 @@ do
     sleep 5
     echo "Checking if SkotOS is responsive yet. The first run can take five to ten minutes until everything is working..."
     curl -L http://localhost:10080/SAM/Prop/Theatre:Web:Theatre/Index > /tmp/test_skotos.html || echo "(curl failed)"
-    grep "Skotos" /tmp/test_skotos.html && break
+    # Note: can sometimes get a "theatre not found" transient error early in bootup
+    grep "Log in to Skotos" /tmp/test_skotos.html && break
 done
 
 cat dev_scripts/post_install_instructions.txt
 
 open -a "Google Chrome" "http://localhost:10080/SAM/Prop/Theatre:Web:Theatre/Index"
+#open -a Terminal -n "telnet localhost 10098"
 # TODO: open iTerm/terminal window to telnet port
-
-
-##################
-# TODO: DockerHub image: https://docs.docker.com/get-started/part3/
-# REF: https://docs.docker.com/storage/bind-mounts/

--- a/dev_scripts/start_server.sh
+++ b/dev_scripts/start_server.sh
@@ -7,7 +7,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd $SCRIPT_DIR
 cd ..
 
-DGD_PID=$(ps aux | grep "dgd ./skotos.dgd" | grep -v grep | cut -c 14-25)
+DGD_PID=$(ps aux | grep "dgd ./skotos.dgd" | grep -v grep | cut -c 14-22)
 if [ -z "$DGD_PID" ]
 then
     echo "DGD does not appear to be running already. Good."
@@ -18,8 +18,8 @@ fi
 
 # Start websocket-to-tcp tunnels for Orchil client and for Tree of WOE
 
-PID1=$(ps aux | grep "listen=10801" | grep -v grep | cut -c 14-25)
-PID2=$(ps aux | grep "listen=10802" | grep -v grep | cut -c 14-25)
+PID1=$(ps aux | grep "listen=10801" | grep -v grep | cut -c 14-22)
+PID2=$(ps aux | grep "listen=10802" | grep -v grep | cut -c 14-22)
 
 if [ -z "$PID1" ]
 then
@@ -43,7 +43,7 @@ fi
 
 # Run NGinX to forward to websocket relays
 
-NG_PID=$(ps aux | grep "nginx: master process" | grep -v grep | cut -c 14-25)
+NG_PID=$(ps aux | grep "nginx: master process" | grep -v grep | cut -c 14-22)
 
 if [ -z "$NG_PID" ]
 then
@@ -58,22 +58,23 @@ cat dev_scripts/post_install_instructions.txt
 if [ -f skotos.database ]
 then
     echo "Hot-booting DGD from existing statedump..."
-    dgd/bin/dgd ./skotos.dgd skotos.database >log/dgd_server.out 2>&1
+    dgd/bin/dgd ./skotos.dgd skotos.database >log/dgd_server.out 2>&1 &
 else
     echo "Cold-booting DGD with no statedump..."
-    dgd/bin/dgd ./skotos.dgd >log/dgd_server.out 2>&1
+    dgd/bin/dgd ./skotos.dgd >log/dgd_server.out 2>&1 &
 fi
 # Open iTerm/terminal window showing DGD process log
 open -a Terminal -n dev_scripts/show_dgd_logs.sh
 
 # Wait until SkotOS is booted and responsive
+sleep 5
 while true
 do
-    sleep 5
     echo "Checking if SkotOS is responsive yet. The first run can take five to ten minutes until everything is working..."
     curl -L http://localhost:10080/SAM/Prop/Theatre:Web:Theatre/Index > /tmp/test_skotos.html || echo "(curl failed)"
     # Note: can sometimes get a "theatre not found" transient error early in bootup
     grep "Log in to Skotos" /tmp/test_skotos.html && break
+    sleep 20
 done
 
 cat dev_scripts/post_install_instructions.txt

--- a/dev_scripts/start_server.sh
+++ b/dev_scripts/start_server.sh
@@ -7,59 +7,33 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd $SCRIPT_DIR
 cd ..
 
-DGD_PID=$(ps aux | grep "dgd ./skotos.dgd" | grep -v grep | cut -c 14-25)
-if [ -z "$DGD_PID" ]
-then
-    echo "DGD does not appear to be running already. Good."
-else
-    echo "DGD appears to be running SkotOS already with PID ${DGD_PID}. Shut down that copy of DGD before running another."
-    false
-fi
+docker ps -a | grep sk && echo "You are already running a Docker container! Run stop_server.sh to remove it."
 
-# Start websocket-to-tcp tunnels for Orchil client and for Tree of WOE
+docker run -p 8080:8080 --mount type=bind,src="$(pwd)/log",target="/var/log" --detach --name sk skotos
 
-PID1=$(ps aux | grep "listen=10801" | grep -v grep | cut -c 14-25)
-PID2=$(ps aux | grep "listen=10802" | grep -v grep | cut -c 14-25)
+# TODO: go through the horrible osascript magic to open a new window (not just tab) consistently:
+#    https://github.com/ohmyzsh/ohmyzsh/blob/master/plugins/osx/osx.plugin.zsh
 
-if [ -z "$PID1" ]
-then
-    echo "Running Relay.js for port 10801->10443"
-    pushd websocket-to-tcp-tunnel
-    nohup node src/Relay.js --listen=10801 --send=10443 --host=localhost --name=gables --wsHeartbeat=30 --shutdownDelay=3 --tunnelInfo=false &
-    popd
-else
-    echo "Relay is already running for port 10801->10443"
-fi
+# Open iTerm/terminal window showing DGD process log
+open -a $TERM_PROGRAM dev_scripts/show_dgd_logs.sh
 
-if [ -z "$PID2" ]
-then
-    echo "Running Relay.js for port 10802->10090"
-    pushd websocket-to-tcp-tunnel
-    nohup node src/Relay.js --listen=10802 --send=10090 --host=localhost --name=gables --wsHeartbeat=30 --shutdownDelay=3 --tunnelInfo=false &
-    popd
-else
-    echo "Relay is already running for port 10802->10090"
-fi
+# TODO: wait until SkotOS is booted and responsive
+while true
+do
+    sleep 5
+    echo "Checking if SkotOS is responsive yet. The first run can take awhile..."
+    curl https://localhost:8080/SAM/Prop/Theatre:Web:Theatre/Index || echo "(curl failed)"
+    grep "" Index && break
+done
 
-# Run NGinX to forward to websocket relays
+open -a $TERM_PROGRAM dev_scripts/show_post_install_instructions.sh
 
-NG_PID=$(ps aux | grep "nginx: master process" | grep -v grep | cut -c 14-25)
 
-if [ -z "$NG_PID" ]
-then
-    sudo nginx
-else
-    echo "NGinX is already running... Reloading config."
-    sudo nginx -s reload
-fi
+# TODO: open iTerm/terminal window to telnet port
+# TODO: open browser window to character creation
 
-cat dev_scripts/post_install_instructions.txt
 
-if [ -f skotos.database ]
-then
-    echo "Hot-booting DGD from existing statedump..."
-    dgd/bin/dgd ./skotos.dgd skotos.database
-else
-    echo "Cold-booting DGD with no statedump..."
-    dgd/bin/dgd ./skotos.dgd
-fi
+
+##################
+# TODO: DockerHub image: https://docs.docker.com/get-started/part3/
+# REF: https://docs.docker.com/storage/bind-mounts/

--- a/dev_scripts/start_server.sh
+++ b/dev_scripts/start_server.sh
@@ -9,7 +9,7 @@ cd ..
 
 docker ps -a | grep sk && echo "You are already running a Docker container! Run stop_server.sh to remove it."
 
-docker run -p 8080:8080 --mount type=bind,src="$(pwd)/log",target="/var/log" --detach --name sk skotos
+docker run --mount type=bind,src="$(pwd)/log",target="/var/log" --detach --name sk skotos
 
 # TODO: go through the horrible osascript magic to open a new window (not just tab) consistently:
 #    https://github.com/ohmyzsh/ohmyzsh/blob/master/plugins/osx/osx.plugin.zsh
@@ -21,14 +21,14 @@ open -a $TERM_PROGRAM dev_scripts/show_dgd_logs.sh
 while true
 do
     sleep 5
-    echo "Checking if SkotOS is responsive yet. The first run can take awhile..."
-    curl https://localhost:8080/SAM/Prop/Theatre:Web:Theatre/Index || echo "(curl failed)"
-    grep "" Index && break
+    echo "Checking if SkotOS is responsive yet. The first run can take five to ten minutes until everything is working..."
+    curl http://localhost:8080/SAM/Prop/Theatre:Web:Theatre/Index > /tmp/test_skotos.html || echo "(curl failed)"
+    grep -i "gables" /tmp/test_skotos.html && break
 done
 
 open -a $TERM_PROGRAM dev_scripts/show_post_install_instructions.sh
 
-
+open -a "Google Chrome" "http://localhost:8080/SAM/Prop/Theatre:Web:Theatre/Index"
 # TODO: open iTerm/terminal window to telnet port
 # TODO: open browser window to character creation
 

--- a/dev_scripts/start_server.sh
+++ b/dev_scripts/start_server.sh
@@ -7,9 +7,16 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd $SCRIPT_DIR
 cd ..
 
+if (docker ps -a | grep sk)
+then
+    # Restart the stopped container, if it's stopped
+    docker start sk || echo "Maybe the Docker container is already running?"
+else
+    # Create a new container
+    docker run -p 10800:10800 -p 10900:10900 -p 10802:10802 -p 10080:10080 -p 10443:10443 --mount type=bind,src="$(pwd)/log",target="/var/log" --detach --name sk skotos
+fi
 docker ps -a | grep sk && echo "You are already running a Docker container! Run stop_server.sh to remove it."
 
-docker run --mount type=bind,src="$(pwd)/log",target="/var/log" --detach --name sk skotos
 
 # TODO: go through the horrible osascript magic to open a new window (not just tab) consistently:
 #    https://github.com/ohmyzsh/ohmyzsh/blob/master/plugins/osx/osx.plugin.zsh
@@ -17,21 +24,19 @@ docker run --mount type=bind,src="$(pwd)/log",target="/var/log" --detach --name 
 # Open iTerm/terminal window showing DGD process log
 open -a $TERM_PROGRAM dev_scripts/show_dgd_logs.sh
 
-# TODO: wait until SkotOS is booted and responsive
+# Wait until SkotOS is booted and responsive
 while true
 do
     sleep 5
     echo "Checking if SkotOS is responsive yet. The first run can take five to ten minutes until everything is working..."
-    curl http://localhost:8080/SAM/Prop/Theatre:Web:Theatre/Index > /tmp/test_skotos.html || echo "(curl failed)"
-    grep -i "gables" /tmp/test_skotos.html && break
+    curl -L http://localhost:10080/SAM/Prop/Theatre:Web:Theatre/Index > /tmp/test_skotos.html || echo "(curl failed)"
+    grep "Skotos" /tmp/test_skotos.html && break
 done
 
-open -a $TERM_PROGRAM dev_scripts/show_post_install_instructions.sh
+cat dev_scripts/post_install_instructions.txt
 
-open -a "Google Chrome" "http://localhost:8080/SAM/Prop/Theatre:Web:Theatre/Index"
+open -a "Google Chrome" "http://localhost:10080/SAM/Prop/Theatre:Web:Theatre/Index"
 # TODO: open iTerm/terminal window to telnet port
-# TODO: open browser window to character creation
-
 
 
 ##################

--- a/dev_scripts/stop_server.sh
+++ b/dev_scripts/stop_server.sh
@@ -1,3 +1,33 @@
 #!/bin/bash
 
-docker stop sk
+# TODO: Do we stop NGinX? Interesting question.
+
+DGD_PID=$(ps aux | grep "dgd ./skotos.dgd" | grep -v grep | cut -c 14-22)
+if [ -z "$DGD_PID" ]
+then
+    echo "DGD does not appear to be running already. Good."
+else
+    echo "DGD appears to be running SkotOS already with PID ${DGD_PID}."
+    kill "$DGD_PID"
+fi
+
+PID1=$(ps aux | grep "listen=10801" | grep -v grep | cut -c 14-22)
+PID2=$(ps aux | grep "listen=10802" | grep -v grep | cut -c 14-22)
+
+if [ -z "$PID1" ]
+then
+    echo "No Relay1 running. Good."
+else
+    echo "Shutting down Relay1 =for port 10801->10443"
+    kill "$PID1"
+fi
+
+if [ -z "$PID2" ]
+then
+    echo "No Relay2 running. Good."
+else
+    echo "Shutting down Relay1 =for port 10802->10090"
+    kill "$PID2"
+fi
+
+echo "Shut down DGD successfully..."

--- a/dev_scripts/stop_server.sh
+++ b/dev_scripts/stop_server.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker rm --force sk

--- a/dev_scripts/stop_server.sh
+++ b/dev_scripts/stop_server.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker rm --force sk
+docker stop sk


### PR DESCRIPTION
This backports the relevant changes (attempting to wait for DGD to be ready, bringing up a terminal with the DGD log, bringing up a browser window) to Mac setup.

It leaves the Docker build directories in place. Those could be removed. It does *not* leave Docker in the Mac setup scripts.

It also adds a partial Stackscript. It isn't fully debugged, but it sets up most of what you want. I'll continue to try to get it working later on.