### PR TITLE
BugFix for Woe and Orchil

### DIFF
--- a/dev_scripts/orchil_profiles.js
+++ b/dev_scripts/orchil_profiles.js
@@ -7,6 +7,7 @@ var profiles = {
                 "server":   "localhost", //"chat.gables.chattheatre.com",
                 "port":      10800,
                 "woe_port":  10802,
+                "http_port": 10080,
                 "path":     "/gables",
                 "extra":    "",
                 "reports":   false,


### PR DESCRIPTION
Updated the profiles.js file to include a http_port reference. This is required for tree of woe and orchil's popup windows to function.