### PR TITLE
Per-game Mac setup

### DIFF
--- a/deploy_scripts/mac_setup/mac_setup.sh
+++ b/deploy_scripts/mac_setup/mac_setup.sh
@@ -6,90 +6,14 @@ set -e
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd $SCRIPT_DIR
 cd ../..
-
 SKOTOS_ROOT="$(pwd)"
 
-DGD_PID=$(pgrep -f "dgd ./skotos.dgd")
-if [ -z "$DGD_PID" ]
-then
-    echo "DGD does not appear to be running. Good."
-else
-    echo "DGD appears to be running SkotOS already with PID ${DGD_PID}. Shut down this copy of DGD with deploy_scripts/mac_setup/stop_server.sh before messing with the install."
-    echo "Or you can run start_server.sh instead of mac_setup.sh. That's fine too."
-    false
-fi
+echo "-------------------------"
+echo "THIS SCRIPT IS OBSOLETE."
+echo "YOU SHOULD BE RUNNING THE SETUP SCRIPT FROM A SKOTOS-BASED APP SUCH AS THE GABLES."
+echo "THIS SCRIPT IS DEPRECATED AND WILL STOP RUNNING AT SOME FUTURE POINT."
+echo "The setup_no_server script is what you want for setting up everything except the DGD process."
+echo "-------------------------"
 
-# This script intends to set up your Mac for SkotOS development. It's as useful to read through
-# as to actually run.
-
-# It should run from the SkotOS root directory.
-
-# Install prereqs: Homebrew
-which brew || /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
-which git || brew install git
-which npm || brew install npm
-
-if [ -f ~/.ssh/id_rsa.pub ]
-then
-    echo "Yes, you have an ~/.ssh/id_rsa.pub"
-else
-    # Generate the key and add it to the Mac keychain
-    echo "You have no RSA public key. You'll need to create one and register it with GitHub! I recommend an empty passphrase for convenience."
-    ssh-keygen -t rsa -f ~/.ssh/id_rsa
-    ssh-add -K ~/.ssh/id_rsa
-fi
-
-if git clone git@github.com:noahgibbs/env_mem.git /tmp/env_mem
-then
-    rm -rf /tmp/env_mem
-    echo "Git clone succeeded - you can clone repos from GitHub."
-else
-    echo "You can't check out a repo on GitHub. That probably means you need to register your SSH key with GitHub. Please check https://github.com/settings/keys and add ~/.ssh/id_rsa.pub so that you can check out repositories."
-    false  # Script will exit with error due to "set -e" above
-fi
-
-# Set up DGD
-if [ -d dgd ]
-then
-    echo "DGD exists... Updating."
-    pushd dgd
-    git pull
-    popd
-else
-    echo "Cloning DGD"
-    git clone git@github.com:ChatTheatre/dgd.git dgd
-fi
-
-pushd dgd/src
-make DEFINES='-DUINDEX_TYPE="unsigned int" -DUINDEX_MAX=UINT_MAX -DEINDEX_TYPE="unsigned short" -DEINDEX_MAX=USHRT_MAX -DSSIZET_TYPE="unsigned int" -DSSIZET_MAX=1048576' install
-popd
-
-# Clone other ChatTheatre repos
-
-if [ -d websocket-to-tcp-tunnel ]
-then
-    echo "Tunnel exists... Updating."
-    pushd websocket-to-tcp-tunnel
-    git pull
-    popd
-else
-    echo "Cloning Tunnel (websocket-to-tcp-tunnel)"
-    git clone git@github.com:ChatTheatre/websocket-to-tcp-tunnel.git websocket-to-tcp-tunnel
-fi
-
-if [ -d wafer ]
-then
-    echo "Clone of Wafer repo exists... Updating."
-    pushd wafer
-    git pull
-    popd
-else
-    echo "Cloning Wafer (dev-mode fake UserDB)"
-    git clone git@github.com:ChatTheatre/wafer.git wafer
-fi
-
-pushd websocket-to-tcp-tunnel
-npm install || echo "Allowing even with outstanding 'npm audit' issues..."
-popd
-
+./deploy_scripts/mac_setup/setup_no_server.sh
 ./deploy_scripts/mac_setup/start_server.sh

--- a/deploy_scripts/mac_setup/mac_setup.sh
+++ b/deploy_scripts/mac_setup/mac_setup.sh
@@ -15,5 +15,7 @@ echo "THIS SCRIPT IS DEPRECATED AND WILL STOP RUNNING AT SOME FUTURE POINT."
 echo "The setup_no_server script is what you want for setting up everything except the DGD process."
 echo "-------------------------"
 
+export GAME_ROOT="$SKOTOS_ROOT"
+
 ./deploy_scripts/mac_setup/setup_no_server.sh
 ./deploy_scripts/mac_setup/start_server.sh

--- a/deploy_scripts/mac_setup/mac_setup.sh
+++ b/deploy_scripts/mac_setup/mac_setup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+set -x
 
 # cd to the SkotOS root directory
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"

--- a/deploy_scripts/mac_setup/poststart_no_server.sh
+++ b/deploy_scripts/mac_setup/poststart_no_server.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [ -z "$GAME_ROOT" ]
+then
+    echo "You must set a GAME_ROOT to run this startup script."
+    exit -1
+fi
+cd "$GAME_ROOT"
+
+# Wait until SkotOS is booted and responsive
+./deploy_scripts/shared/wait_for_full_boot.sh
+
+# We killed Wafer up-top, so we can just run it here.
+echo "Running Wafer (auth server)"
+pushd wafer
+ruby -Ilib ./exe/wafer >../log/wafer_log.txt 2>&1 &
+popd

--- a/deploy_scripts/mac_setup/poststart_no_server.sh
+++ b/deploy_scripts/mac_setup/poststart_no_server.sh
@@ -16,5 +16,6 @@ cd "$GAME_ROOT"
 # We killed Wafer up-top, so we can just run it here.
 echo "Running Wafer (auth server)"
 pushd wafer
-ruby -Ilib ./exe/wafer >../log/wafer_log.txt 2>&1 &
+bundle
+bundle exec ruby -Ilib ./exe/wafer >../log/wafer_log.txt 2>&1 &
 popd

--- a/deploy_scripts/mac_setup/poststart_no_server.sh
+++ b/deploy_scripts/mac_setup/poststart_no_server.sh
@@ -3,6 +3,12 @@
 set -e
 set -x
 
+# cd to the SkotOS root directory
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd $SCRIPT_DIR
+cd ../..
+SKOTOS_ROOT="$(pwd)"
+
 if [ -z "$GAME_ROOT" ]
 then
     echo "You must set a GAME_ROOT to run this startup script."
@@ -11,9 +17,8 @@ fi
 cd "$GAME_ROOT"
 
 # Wait until SkotOS is booted and responsive
-./deploy_scripts/shared/wait_for_full_boot.sh
+"$SKOTOS_ROOT/deploy_scripts/shared/wait_for_full_boot.sh"
 
-# We killed Wafer up-top, so we can just run it here.
 echo "Running Wafer (auth server)"
 pushd wafer
 bundle

--- a/deploy_scripts/mac_setup/prestart_no_server.sh
+++ b/deploy_scripts/mac_setup/prestart_no_server.sh
@@ -18,7 +18,7 @@ else
     kill $WAFER_PID
     sleep 0.5
     kill -9 $WAFER_PID
-    rm -f ../log/wafer_log.txt
+    rm -f log/wafer_log.txt
 fi
 
 WAFER_PID=$(pgrep -f "ruby -Ilib ./exe/wafer") || echo "Wafer wrapper not running, which is fine"
@@ -27,7 +27,7 @@ then
     echo "Wafer wrapper is not yet running - good, it can get wedged."
 else
     kill -9 $WAFER_PID
-    rm -f ../log/wafer_log.txt
+    rm -f log/wafer_log.txt
 fi
 
 # Start websocket-to-tcp tunnels for Orchil client and for Tree of WOE

--- a/deploy_scripts/mac_setup/prestart_no_server.sh
+++ b/deploy_scripts/mac_setup/prestart_no_server.sh
@@ -15,9 +15,9 @@ if [ -z "$WAFER_PID" ]
 then
     echo "Wafer's web server is not running - good, it can get wedged."
 else
-    kill $WAFER_PID
+    kill $WAFER_PID # Error on first kill wouldn't be good
     sleep 0.5
-    kill -9 $WAFER_PID
+    kill -9 $WAFER_PID || echo "Error on kill -9, that means Wafer exited gracefully"
     rm -f log/wafer_log.txt
 fi
 

--- a/deploy_scripts/mac_setup/prestart_no_server.sh
+++ b/deploy_scripts/mac_setup/prestart_no_server.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [ -z "$GAME_ROOT" ]
+then
+    echo "You must set a GAME_ROOT to run this startup script."
+    exit -1
+fi
+cd "$GAME_ROOT"
+
+WAFER_PID=$(pgrep -f "rackup -p 2072") || echo "Wafer's web server not yet running, which is fine"
+if [ -z "$WAFER_PID" ]
+then
+    echo "Wafer's web server is not running - good, it can get wedged."
+else
+    kill $WAFER_PID
+    sleep 0.5
+    kill -9 $WAFER_PID
+    rm -f ../log/wafer_log.txt
+fi
+
+WAFER_PID=$(pgrep -f "ruby -Ilib ./exe/wafer") || echo "Wafer wrapper not running, which is fine"
+if [ -z "$WAFER_PID" ]
+then
+    echo "Wafer wrapper is not yet running - good, it can get wedged."
+else
+    kill -9 $WAFER_PID
+    rm -f ../log/wafer_log.txt
+fi
+
+# Start websocket-to-tcp tunnels for Orchil client and for Tree of WOE
+PID1=$(pgrep -f "listen=10801") || echo "Relay1 not yet running, which is fine"
+PID2=$(pgrep -f "listen=10802") || echo "Relay2 not yet running, which is fine"
+
+if [ -z "$PID1" ]
+then
+    echo "Running Relay.js for port 10801->10443"
+    pushd websocket-to-tcp-tunnel
+    nohup node src/Relay.js --listen=10801 --send=10443 --host=localhost --name=gables --wsHeartbeat=30 --shutdownDelay=3 --tunnelInfo=false &
+    popd
+else
+    echo "Relay is already running for port 10801->10443"
+fi
+
+if [ -z "$PID2" ]
+then
+    echo "Running Relay.js for port 10802->10090"
+    pushd websocket-to-tcp-tunnel
+    nohup node src/Relay.js --listen=10802 --send=10090 --host=localhost --name=gables --wsHeartbeat=30 --shutdownDelay=3 --tunnelInfo=false &
+    popd
+else
+    echo "Relay is already running for port 10802->10090"
+fi

--- a/deploy_scripts/mac_setup/setup_no_server.sh
+++ b/deploy_scripts/mac_setup/setup_no_server.sh
@@ -16,7 +16,7 @@ fi
 
 cd "$GAME_ROOT"
 
-DGD_PID=$(pgrep -f "dgd ./skotos.dgd")
+DGD_PID=$(pgrep -f "dgd ./skotos.dgd") || echo "DGD not running, which is fine."
 if [ -z "$DGD_PID" ]
 then
     echo "DGD does not appear to be running. Good."

--- a/deploy_scripts/mac_setup/setup_no_server.sh
+++ b/deploy_scripts/mac_setup/setup_no_server.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+set -e
+
+# cd to the SkotOS root directory
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd $SCRIPT_DIR
+cd ../..
+SKOTOS_ROOT="$(pwd)"
+
+if [ -z "$GAME_ROOT" ]
+then
+    echo "You must set a GAME_ROOT to run this setup script."
+    exit -1
+fi
+
+cd "$GAME_ROOT"
+
+DGD_PID=$(pgrep -f "dgd ./skotos.dgd")
+if [ -z "$DGD_PID" ]
+then
+    echo "DGD does not appear to be running. Good."
+else
+    echo "DGD appears to be running SkotOS already with PID ${DGD_PID}. Shut down this copy of DGD with deploy_scripts/mac_setup/stop_server.sh before messing with the install."
+    echo "Or you can run start_server.sh instead of mac_setup.sh. That's fine too."
+    false
+fi
+
+# This script intends to set up your Mac for SkotOS development. It's as useful to read through
+# as to actually run.
+
+# It should run from the SkotOS root directory.
+
+# Install prereqs: Homebrew
+which brew || /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+which git || brew install git
+which npm || brew install npm
+
+if [ -f ~/.ssh/id_rsa.pub ]
+then
+    echo "Yes, you have an ~/.ssh/id_rsa.pub"
+else
+    # Generate the key and add it to the Mac keychain
+    echo "You have no RSA public key. You'll need to create one and register it with GitHub! I recommend an empty passphrase for convenience."
+    ssh-keygen -t rsa -f ~/.ssh/id_rsa
+    ssh-add -K ~/.ssh/id_rsa
+fi
+
+if git clone git@github.com:noahgibbs/env_mem.git /tmp/env_mem
+then
+    rm -rf /tmp/env_mem
+    echo "Git clone succeeded - you can clone repos from GitHub."
+else
+    echo "You can't check out a repo on GitHub. That probably means you need to register your SSH key with GitHub. Please check https://github.com/settings/keys and add ~/.ssh/id_rsa.pub so that you can check out repositories."
+    false  # Script will exit with error due to "set -e" above
+fi
+
+# Set up DGD
+if [ -d dgd ]
+then
+    echo "DGD exists... Updating."
+    pushd dgd
+    git pull
+    popd
+else
+    echo "Cloning DGD"
+    git clone git@github.com:ChatTheatre/dgd.git dgd
+fi
+
+pushd dgd/src
+make DEFINES='-DUINDEX_TYPE="unsigned int" -DUINDEX_MAX=UINT_MAX -DEINDEX_TYPE="unsigned short" -DEINDEX_MAX=USHRT_MAX -DSSIZET_TYPE="unsigned int" -DSSIZET_MAX=1048576' install
+popd
+
+# Clone other ChatTheatre repos
+
+if [ -d websocket-to-tcp-tunnel ]
+then
+    echo "Tunnel exists... Updating."
+    pushd websocket-to-tcp-tunnel
+    git pull
+    popd
+else
+    echo "Cloning Tunnel (websocket-to-tcp-tunnel)"
+    git clone git@github.com:ChatTheatre/websocket-to-tcp-tunnel.git websocket-to-tcp-tunnel
+fi
+
+if [ -d wafer ]
+then
+    echo "Clone of Wafer repo exists... Updating."
+    pushd wafer
+    git pull
+    popd
+else
+    echo "Cloning Wafer (dev-mode fake UserDB)"
+    git clone git@github.com:ChatTheatre/wafer.git wafer
+fi
+
+pushd websocket-to-tcp-tunnel
+npm install || echo "Allowing even with outstanding 'npm audit' issues..."
+popd

--- a/deploy_scripts/mac_setup/setup_no_server.sh
+++ b/deploy_scripts/mac_setup/setup_no_server.sh
@@ -17,7 +17,7 @@ fi
 
 cd "$GAME_ROOT"
 
-DGD_PID=$(pgrep -f "dgd ./skotos.dgd") || echo "DGD not running, which is fine."
+DGD_PID=$(pgrep -f "dgd/bin/dgd") || echo "DGD not running, which is fine."
 if [ -z "$DGD_PID" ]
 then
     echo "DGD does not appear to be running. Good."

--- a/deploy_scripts/mac_setup/setup_no_server.sh
+++ b/deploy_scripts/mac_setup/setup_no_server.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+set -x
 
 # cd to the SkotOS root directory
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"

--- a/deploy_scripts/mac_setup/show_dgd_logs.sh
+++ b/deploy_scripts/mac_setup/show_dgd_logs.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-set -e
+if [ -z "$GAME_ROOT" ]
+then
+    echo "You must set a GAME_ROOT to run this setup script."
+    exit -1
+fi
 
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-cd $SCRIPT_DIR
-cd ../..
-
-tail -f $(pwd)/log/dgd_server.out $(pwd)/log/wafer_log.txt
+tail -f "$GAME_ROOT/log/dgd_server.out" "$GAME_ROOT/log/wafer_log.txt"

--- a/deploy_scripts/mac_setup/start_server.sh
+++ b/deploy_scripts/mac_setup/start_server.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
-# This is an example start script, similar to the ones other SkotOS games should supply.
+# This is an example start script, similar to the ones other SkotOS games
+# should supply. See https://github.com/ChatTheatre/gables_game for an
+# example of what a customised version might look like.
+
+# A heavily-customised game may need to stop using the standard startup and
+# shutdown scripts. But if you *can* use them it can save you some headache.
 
 set -e
 set -x

--- a/deploy_scripts/mac_setup/start_server.sh
+++ b/deploy_scripts/mac_setup/start_server.sh
@@ -2,7 +2,7 @@
 
 # This is an example start script, similar to the ones other SkotOS games
 # should supply. See https://github.com/ChatTheatre/gables_game for an
-# example of what a customised version might look like.
+# example of what a barely-customised version might look like.
 
 # A heavily-customised game may need to stop using the standard startup and
 # shutdown scripts. But if you *can* use them it can save you some headache.
@@ -34,7 +34,7 @@ else
 fi
 
 # Open iTerm/terminal window showing DGD process log
-open -a Terminal -n deploy_scripts/mac_setup/show_dgd_logs.sh
+open -a $TERM_PROGRAM -n deploy_scripts/mac_setup/show_dgd_logs.sh
 
 # Wait until SkotOS is booted and responsive, start auth server
 ./deploy_scripts/mac_setup/poststart_no_server.sh

--- a/deploy_scripts/mac_setup/start_server.sh
+++ b/deploy_scripts/mac_setup/start_server.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# This is an example start script, similar to the ones other SkotOS games should supply.
+
 set -e
 set -x
 
@@ -7,50 +9,9 @@ set -x
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd $SCRIPT_DIR
 cd ../..
+export GAME_ROOT="$(pwd)"
 
-WAFER_PID=$(pgrep -f "rackup -p 2072") || echo "Wafer's web server not yet running, which is fine"
-if [ -z "$WAFER_PID" ]
-then
-    echo "Wafer's web server is not running - good, it can get wedged."
-else
-    kill $WAFER_PID
-    sleep 0.5
-    kill -9 $WAFER_PID
-    rm -f ../log/wafer_log.txt
-fi
-
-WAFER_PID=$(pgrep -f "ruby -Ilib ./exe/wafer") || echo "Wafer wrapper not running, which is fine"
-if [ -z "$WAFER_PID" ]
-then
-    echo "Wafer wrapper is not yet running - good, it can get wedged."
-else
-    kill -9 $WAFER_PID
-    rm -f ../log/wafer_log.txt
-fi
-
-# Start websocket-to-tcp tunnels for Orchil client and for Tree of WOE
-PID1=$(pgrep -f "listen=10801") || echo "Relay1 not yet running, which is fine"
-PID2=$(pgrep -f "listen=10802") || echo "Relay2 not yet running, which is fine"
-
-if [ -z "$PID1" ]
-then
-    echo "Running Relay.js for port 10801->10443"
-    pushd websocket-to-tcp-tunnel
-    nohup node src/Relay.js --listen=10801 --send=10443 --host=localhost --name=gables --wsHeartbeat=30 --shutdownDelay=3 --tunnelInfo=false &
-    popd
-else
-    echo "Relay is already running for port 10801->10443"
-fi
-
-if [ -z "$PID2" ]
-then
-    echo "Running Relay.js for port 10802->10090"
-    pushd websocket-to-tcp-tunnel
-    nohup node src/Relay.js --listen=10802 --send=10090 --host=localhost --name=gables --wsHeartbeat=30 --shutdownDelay=3 --tunnelInfo=false &
-    popd
-else
-    echo "Relay is already running for port 10802->10090"
-fi
+./deploy_scripts/mac_setup/prestart_no_server.sh
 
 DGD_PID=$(pgrep -f "dgd ./skotos.dgd") || echo "DGD not yet running, which is fine"
 if [ -z "$DGD_PID" ]
@@ -70,16 +31,10 @@ fi
 # Open iTerm/terminal window showing DGD process log
 open -a Terminal -n deploy_scripts/mac_setup/show_dgd_logs.sh
 
-# Wait until SkotOS is booted and responsive
-./deploy_scripts/shared/wait_for_full_boot.sh
+# Wait until SkotOS is booted and responsive, start auth server
+./deploy_scripts/mac_setup/poststart_no_server.sh
 
-# We killed Wafer up-top, so we can just run it here.
-echo "Running Wafer (auth server)"
-pushd wafer
-ruby -Ilib ./exe/wafer >../log/wafer_log.txt 2>&1 &
-popd
-
-cat deploy_scripts/mac_setup/post_install_instructions.txt
+cat ./deploy_scripts/mac_setup/post_install_instructions.txt
 
 open -a "Google Chrome" "http://localhost:2072/"
 #open -a Terminal -n "telnet localhost 10098"

--- a/skoot/usr/Gables/data/www/profiles.js
+++ b/skoot/usr/Gables/data/www/profiles.js
@@ -1,7 +1,7 @@
 "use strict";
 // orchil/profiles.js
 var profiles = {
-        "portal_game":{
+        "portal_gables":{
                 "method":   "websocket",
                 "protocol": "ws",
                 "server":   "localhost", //"chat.gables.chattheatre.com",

--- a/skoot/usr/Gables/data/www/profiles.js
+++ b/skoot/usr/Gables/data/www/profiles.js
@@ -1,7 +1,7 @@
 "use strict";
 // orchil/profiles.js
 var profiles = {
-        "portal_gables":{
+        "portal_game":{
                 "method":   "websocket",
                 "protocol": "ws",
                 "server":   "localhost", //"chat.gables.chattheatre.com",


### PR DESCRIPTION
While SkotOS has had local Mac setup scripts for some time, there wasn't an easy way to use them from SkotOS-derived games (e.g. gables_game, RWOT.) While I'm not getting rid of standalone SkotOS local dev (yet), I *am* marking the top-level scripts for it deprecated and printing a warning to console -- soon, if you want to run a SkotOS game it'll need to be a separate game that *uses* SkotOS.

And now they have a proper local dev mode with scripts in the SkotOS library, but they can easily hook in and add customisations. It works a lot like the stackscripts - SkotOS has a central version that does *not* start DGD. So it's fairly easy to "wrap" it with your game-specific version and customise it afterward, then start DGD for yourself. That's also what the SkotOS-only scripts do, for now. They will eventually break when/if SkotOS stops including a start area and a Theatre object built-in.