### PR TITLE
Exits command merryized

### DIFF
--- a/skoot/data/vault/Lib/exits.xml
+++ b/skoot/data/vault/Lib/exits.xml
@@ -1,0 +1,92 @@
+<object clone="/obj/properties" owner="SkotOS">
+  <Core:PropertyContainer>
+    <Ur:UrObject/>
+    <Core:PCProperties>
+      <Core:Property property="merry:lib:find_exits">
+         X[M] /*
+**
+** \$room - room we are checking for exits
+**
+*/
+
+string *details;
+object env, *inv;
+mixed *exits;
+int i, j;
+
+exits = (\{ \});
+env = \$room;
+
+if(!env) return FALSE;
+
+details = env."base:details";
+
+for(i = 0; i \< sizeof(details); i++) \{
+    if(Call(\$\{Lib:exits\}, "query_exit", \$detail: NewNRef(env, details[i]))) \{
+        exits += (\{ NewNRef(env, details[i]) \});
+    \}
+\}
+
+inv = env."base:inventory";
+
+for(i = 0; i \< sizeof(inv); i++) \{
+    details = inv[i]."base:details";
+
+    if(!details) continue;
+
+    for(j = 0; j \< sizeof(details); j++) \{
+        if(Get(inv[i], "details:" + details[i] + ":face") \&\&
+           Get(inv[i], "details:" + details[i] + ":face") == "outside") \{
+       
+            exits += (\{ NewNRef(inv[i], details[j]) \});
+        \}
+    \}
+\}
+
+return exits;
+      </Core:Property>
+      <Core:Property property="merry:lib:query_exit">
+         X[M] /*
+**
+** \$detail - NREF of detail to check if visible exit
+**
+*/
+
+object env;
+string detail;
+
+env = NRefOb(\$detail);
+detail = NRefDetail(\$detail);
+
+/* Check if the detail is hidden. If it is, don't show it. */
+if(Get(env, "details:" + detail + ":hidden")) \{
+    return FALSE;
+\}
+
+/* Check if the detail has a destination. If not, it's not visible as an exit */
+if(!Get(env, "details:" + detail + ":exit:dest")) \{
+    return FALSE;
+\}
+
+/* Check if the detail is flagged as never obvious. If it is, don't show it. */
+if(Get(env, "details:" + detail + ":never-obvious")) \{
+    return FALSE;
+\}
+
+/* Check if the exit is a closed door. If so, don't show it under either of the conditions: hidden-when-closed or obvious-when-open. */
+if((Get(env, "details:" + detail + ":exit:door") \&\& Get(env, "details:" + detail + ":exit:closed")) \&\&
+   (Get(env, "details:" + detail + ":hidden-when-closed") \|\| Get(env, "details:" + detail + ":obvious-when-open"))) \{
+            return FALSE;
+\}
+
+/* All conditions have been met. This is a visible exit. */
+
+return TRUE;
+      </Core:Property>
+      <Core:Property property="revisions">
+         (\{ 1144052088, "-", "SYNC", 1638478029, "bobo", "E", 1638481508, "bobo", "E", 1638481716, "bobo", "E", 1638481836, "bobo", "E", 1638481875, "bobo", "E", 1638481965, "bobo", "E", 1638482045, "bobo", "E", 1638482101, "bobo", "E", 1638482147, "bobo", "E" \})
+      </Core:Property>
+    </Core:PCProperties>
+    <Notes:Notes/>
+  </Core:PropertyContainer>
+</object>

--- a/skoot/data/vault/Neoct/Base/Verbs/exits.xml
+++ b/skoot/data/vault/Neoct/Base/Verbs/exits.xml
@@ -1,0 +1,63 @@
+<object clone="/usr/SkotOS/obj/verb" owner="SkotOS">
+  <Socials:Verb imp="exits" evoke="forbidden" audible="false" private="false" secret="false" obscured="false" target-abstracts="false" disabled="false" ooc="false" raw_verb="false">
+    <Ur:UrObject/>
+    <Socials:SocialObjects/>
+    <Socials:VerbActions/>
+    <Core:Properties>
+      <Core:Property property="merry:global:command">
+         X[M] mixed *exits;
+object env;
+string output, detail;
+int i, sz;
+string *dirs;
+
+exits = (\{ \});
+env = \$actor."base:environment";
+
+if(!env) return FALSE;
+
+exits = Call(\$\{Lib:exits\}, "find_exits", \$room: env);
+
+if(!sizeof(exits)) \{
+    EmitTo(\$actor, "There are no obvious exits.");
+    return FALSE;
+\}
+
+output = "You may leave through ";
+
+for(i = 0; i \< sizeof(exits); i++) \{
+    dirs = nil;
+    env = NRefOb(exits[i]);
+    detail = NRefDetail(exits[i]);
+    dirs = Get(env, "details:" + detail + ":exit:directions");
+
+    if(sizeof(dirs)) \{
+        output += "\<acmd cmd=\\"go " + dirs[0] + "\\"\>" + Describe(exits[i]) + "\</acmd\>(" + implode(dirs, ", ") + ")";
+    \} else \{
+        output += "\<acmd cmd=\\"enter " + Describe(exits[i]) + "\\"\>" + Describe(exits[i]) + "\</acmd\>(enter)";
+    \}
+
+    sz = sizeof(exits);
+    if(sz \>= 3) \{
+        if(i \< sz-3) \{
+            output += ", ";
+        \} else if(i \< sz-2) \{
+            output += " and ";
+        \}
+    \} else if(sz == 2) \{
+        if(i \< sz-1) \{
+            output += " and ";
+        \}
+    \}
+\}
+EmitTo(\$actor, UnSAM(ParseXML(output + ".")));
+
+return FALSE;
+      </Core:Property>
+      <Core:Property property="revisions">
+         (\{ 1638484138, "bobo", "E" \})
+      </Core:Property>
+    </Core:Properties>
+    <Notes:Notes/>
+  </Socials:Verb>
+</object>

--- a/skoot/usr/TextIF/cmd/misc.c
+++ b/skoot/usr/TextIF/cmd/misc.c
@@ -54,55 +54,6 @@ void patch() {
 
 void cmd_follow( object user, object body, varargs mixed s);
 void cmd_restrain ( object user, object body, varargs mixed s);
-
-
-void cmd_exits(object user, object body, varargs string foo) {
-  string *details;
-  object env, *inv;
-  NRef *exits;
-  int i, j;
-
-  exits = ({ });
-  env = body->query_environment();
-
-  if (!env)
-    return;
-
-  details = ur_match_exit_details(env, nil, TRUE);
-
-  if (details) {
-    for(i = 0; i < sizeof(details); i++) {
-      exits += ({ NewNRef(env, details[i]) });
-    }
-  }
-
-  inv = env->query_inventory() - ({ body });
-
-  for(i = 0; i < sizeof(inv); i++) {
-    details = ur_match_exit_details(inv[i], "outside", TRUE);
-      
-    if (!details)
-      continue;
-
-    for(j = 0; j < sizeof(details); j++) {
-      exits += ({ NewNRef(inv[i], details[j]) });
-    }
-  }
-
-  if (!sizeof(exits)) {
-    user->paragraph("There are no obvious exits.");
-    return;
-  }
-
-  if (body->query_property("client:theme")) {
-     foo = "foo";
-  }
-
-  DEBUG("exits = " + dump_value(exits));
-  user->html_message("You may leave through " + 
-		     describe_exits(exits) + ".\n");
-}
-
  
 void cmd_tip( object user, object body, varargs string *topic ) {
   if (topic) {

--- a/skoot/usr/TextIF/grammar/basic.y
+++ b/skoot/usr/TextIF/grammar/basic.y
@@ -63,7 +63,7 @@ GrammarBegin
     <COMMAND verb="who"/>
     <COMMAND verb="who" format="%s Word"/>
 
-    <COMMAND verb="exits"/>
+
 
     <COMMAND verb="profile" keywords="theme,themes,none">
         <FORMAT value="%s"/>


### PR DESCRIPTION
Rewrote exits command in Merry. Woe objects added:
* Lib:exits
* Neoct:Base:Verbs:exits


Removed exit code from the following DGD files:
* skoot/usr/TextIF/cmd/misc.c -> void cmd_exits
* skoot/usr/TextIF/grammar/basic.y -> exits command tag