### PR TITLE
Add 'SkotOS Classic' goods file for original SkotOS libs

### DIFF
--- a/plugins/classic.goods
+++ b/plugins/classic.goods
@@ -1,0 +1,18 @@
+{
+    "name": "SkotOS Classic Plugins",
+    "git": {
+        "url": "https://github.com/ChatTheatre/SkotOS.git",
+        "branch": "master"
+    },
+    "paths": {},
+    "dependencies": [
+        "https://raw.githubusercontent.com/ChatTheatre/mgeneric-plugin/main/mgeneric-plugin.goods",
+        "https://raw.githubusercontent.com/ChatTheatre/mgeneric-combat-plugin/main/mgeneric-combat-plugin.goods",
+        "https://raw.githubusercontent.com/ChatTheatre/language-plugin/main/language-plugin.goods",
+        "https://raw.githubusercontent.com/ChatTheatre/article-plugin/main/article-plugin.goods",
+        "https://raw.githubusercontent.com/ChatTheatre/nip-plugin/main/nip-plugin.goods",
+        "https://raw.githubusercontent.com/ChatTheatre/azmail-plugin/main/azmail-plugin.goods",
+        "https://raw.githubusercontent.com/ChatTheatre/effects-plugin/main/effects-plugin.goods",
+        "https://raw.githubusercontent.com/ChatTheatre/shared-plugin/main/shared-plugin.goods"
+    ]
+}


### PR DESCRIPTION
This should include all extracted plugins. It's not 100% working for RWOT yet, but it's clearly an improvement. I'll keep at it.