### PR TITLE
Notes rewritten

### DIFF
--- a/skoot/data/vault/Neoct/Staff/Guides/Verbs/!addnote.xml
+++ b/skoot/data/vault/Neoct/Staff/Guides/Verbs/!addnote.xml
@@ -1,0 +1,13 @@
+<object clone="/usr/SkotOS/obj/verb" owner="bobo">
+  <Socials:Verb imp="!addnote" evoke="forbidden" audible="false" private="false" secret="false" obscured="false" target-abstracts="false" disabled="false" ooc="false" raw_verb="true">
+    <Ur:UrObject urobject="OBJ(Neoct:Staff:Verbs:+addnote)"/>
+    <Socials:SocialObjects/>
+    <Socials:VerbActions/>
+    <Core:Properties>
+      <Core:Property property="revisions">
+         (\{ 1144052091, "-", "SYNC", 1641669036, "bobo", "E", 1641669045, "bobo", "E", 1642970507, "bobo", "E" \})
+      </Core:Property>
+    </Core:Properties>
+    <Notes:Notes/>
+  </Socials:Verb>
+</object>

--- a/skoot/data/vault/Neoct/Staff/Guides/Verbs/!killnote.xml
+++ b/skoot/data/vault/Neoct/Staff/Guides/Verbs/!killnote.xml
@@ -1,0 +1,13 @@
+<object clone="/usr/SkotOS/obj/verb" owner="bobo">
+  <Socials:Verb imp="!killnote" evoke="forbidden" audible="false" private="false" secret="false" obscured="false" target-abstracts="false" disabled="false" ooc="false" raw_verb="true">
+    <Ur:UrObject urobject="OBJ(Neoct:Staff:Verbs:+killnote)"/>
+    <Socials:SocialObjects/>
+    <Socials:VerbActions/>
+    <Core:Properties>
+      <Core:Property property="revisions">
+         (\{ 1144052091, "-", "SYNC", 1641669036, "bobo", "E", 1641669045, "bobo", "E", 1642970507, "bobo", "E", 1642970533, "bobo", "E" \})
+      </Core:Property>
+    </Core:Properties>
+    <Notes:Notes/>
+  </Socials:Verb>
+</object>

--- a/skoot/data/vault/Neoct/Staff/Guides/Verbs/!notes.xml
+++ b/skoot/data/vault/Neoct/Staff/Guides/Verbs/!notes.xml
@@ -1,0 +1,13 @@
+<object clone="/usr/SkotOS/obj/verb" owner="bobo">
+  <Socials:Verb imp="!notes" evoke="forbidden" audible="false" private="false" secret="false" obscured="false" target-abstracts="false" disabled="false" ooc="false" raw_verb="true">
+    <Ur:UrObject urobject="OBJ(Neoct:Staff:Verbs:+notes)"/>
+    <Socials:SocialObjects/>
+    <Socials:VerbActions/>
+    <Core:Properties>
+      <Core:Property property="revisions">
+         (\{ 1144052091, "-", "SYNC", 1641669036, "bobo", "E", 1641669045, "bobo", "E", 1642970507, "bobo", "E", 1642970533, "bobo", "E", 1642970556, "bobo", "E" \})
+      </Core:Property>
+    </Core:Properties>
+    <Notes:Notes/>
+  </Socials:Verb>
+</object>

--- a/skoot/data/vault/Neoct/Staff/Verbs/%2Baddnote.xml
+++ b/skoot/data/vault/Neoct/Staff/Verbs/%2Baddnote.xml
@@ -1,0 +1,48 @@
+<object clone="/usr/SkotOS/obj/verb" owner="bobo">
+  <Socials:Verb imp="+addnote" evoke="forbidden" audible="false" private="false" secret="false" obscured="false" target-abstracts="false" disabled="false" ooc="true" raw_verb="true">
+    <Ur:UrObject/>
+    <Socials:SocialObjects/>
+    <Socials:VerbActions/>
+    <Core:Properties>
+      <Core:Property property="merry:global:command">
+         X[M] string help, head, desc, body, user, note;
+int timestamp;
+
+help = "Usage: " + \$imperative + " \<username\> [\\"...note...\\"]\\n";
+
+if(!\$line) \{
+    EmitTo(\$actor, PRE(help));
+    return FALSE;
+\}
+
+if(sscanf(\$line, "%s \\"%s", user, note) != 2) \{
+    EmitTo(\$actor, PRE(help));
+    return FALSE;
+\}
+
+note = replace_strings(note, "\\"", "");
+
+if(!udat::query_udat(\$name: user)) \{
+    EmitTo(\$actor, "Could not find a user named \\"" + user + "\\".");
+    return FALSE;
+\}
+
+timestamp = time();
+body = Describe(\$actor) + "[" + \$actor."skotos:creator" + "]";
+
+head = "[" + humanized_date(timestamp) + "] " + body + " added a note to " + user + "'s account";
+desc = note;
+
+udat::addnote(\$user: user, \$note: note, \$body: body, \$timestamp: timestamp, \$head: head, \$desc: desc);
+
+EmitTo(\$actor, head + ": " + desc);
+
+return FALSE;
+      </Core:Property>
+      <Core:Property property="revisions">
+         (\{ 1642967251, "bobo", "E", 1642967766, "bobo", "E", 1642967788, "bobo", "E", 1642967856, "bobo", "P", 1642967886, "bobo", "P", 1642968013, "bobo", "P", 1642968171, "bobo", "P", 1642969758, "bobo", "E", 1642969807, "bobo", "E", 1642970242, "bobo", "E" \})
+      </Core:Property>
+    </Core:Properties>
+    <Notes:Notes/>
+  </Socials:Verb>
+</object>

--- a/skoot/data/vault/Neoct/Staff/Verbs/%2Bkillnote.xml
+++ b/skoot/data/vault/Neoct/Staff/Verbs/%2Bkillnote.xml
@@ -1,0 +1,46 @@
+<object clone="/usr/SkotOS/obj/verb" owner="bobo">
+  <Socials:Verb imp="+killnote" evoke="forbidden" audible="false" private="false" secret="false" obscured="false" target-abstracts="false" disabled="false" ooc="true" raw_verb="true">
+    <Ur:UrObject/>
+    <Socials:SocialObjects/>
+    <Socials:VerbActions/>
+    <Core:Properties>
+      <Core:Property property="merry:global:command">
+         X[M] string help, head, desc, body, user;
+int time;
+
+help = "Usage: " + \$imperative + " \<username\>\\n";
+
+if(!\$line) \{
+    EmitTo(\$actor, PRE(help));
+    return FALSE;
+\}
+
+if(sscanf(\$line, "%s", user) != 1) \{
+    EmitTo(\$actor, PRE(help));
+    return FALSE;
+\}
+
+if(!udat::query_udat(\$name: user)) \{
+    EmitTo(\$actor, "Could not find a user named \\"" + user + "\\".");
+    return FALSE;
+\}
+
+time = time();
+body = "[" + humanized_date(time) + "] " + Describe(\$actor) + "[" + \$actor."skotos:creator" + "]";
+
+head = body + " removed a note from " + user + "'s account";
+desc = head;
+
+udat::killnote(\$user: user, \$body: body, \$timestamp: time, \$head: head, \$desc: desc);
+
+EmitTo(\$actor, head);
+
+return FALSE;
+      </Core:Property>
+      <Core:Property property="revisions">
+         (\{ 1642967251, "bobo", "E", 1642967766, "bobo", "E", 1642967788, "bobo", "E", 1642967856, "bobo", "P", 1642967886, "bobo", "P", 1642968013, "bobo", "P", 1642968171, "bobo", "P", 1642968373, "bobo", "E", 1642968551, "bobo", "E" \})
+      </Core:Property>
+    </Core:Properties>
+    <Notes:Notes/>
+  </Socials:Verb>
+</object>

--- a/skoot/data/vault/Neoct/Staff/Verbs/%2Bnotes.xml
+++ b/skoot/data/vault/Neoct/Staff/Verbs/%2Bnotes.xml
@@ -1,0 +1,59 @@
+<object clone="/usr/SkotOS/obj/verb" owner="bobo">
+  <Socials:Verb imp="+notes" evoke="forbidden" audible="false" private="false" secret="false" obscured="false" target-abstracts="false" disabled="false" ooc="true" raw_verb="true">
+    <Ur:UrObject/>
+    <Socials:SocialObjects/>
+    <Socials:VerbActions/>
+    <Core:Properties>
+      <Core:Property property="merry:global:command">
+         X[M] string help, body, user, note, str;
+int timestamp, i;
+mixed *notes;
+
+help = "Usage: " + \$imperative + " \<username\>\\n";
+
+if(!\$line) \{
+    EmitTo(\$actor, PRE(help));
+    return FALSE;
+\}
+
+if(sscanf(\$line, "%s", user) != 1) \{
+    EmitTo(\$actor, PRE(help));
+    return FALSE;
+\}
+
+if(!udat::query_udat(\$name: user)) \{
+    EmitTo(\$actor, "Could not find a user named \\"" + user + "\\".");
+    return FALSE;
+\}
+
+notes = udat::notes(\$user: user);
+
+if(!sizeof(notes)) \{
+    EmitTo(\$actor, "No notes have been entered for that user.");
+\} else \{
+    str = "-------------------------------------------------------------------------------\\n";
+    for(i = 0; i \< sizeof(notes); i++) \{
+        note = notes[i][0];
+        body = notes[i][1];
+        timestamp = notes[i][2];
+
+        str += "\\nDate Filed: " + ctime(Int(timestamp)) + "\\n"
+            + "Written by: " + body + "\\n\\n"
+            + common::wrap(\$string: note, \$maxlength: 75) + "\\n\\n";
+
+        str += "\\n-------------------------------------------------------------------------------\\n";
+    \}
+
+    common::more(\$text: str, \$pre: TRUE, \$append: FALSE);
+\}
+
+
+return FALSE;
+      </Core:Property>
+      <Core:Property property="revisions">
+         (\{ 1642967251, "bobo", "E", 1642967766, "bobo", "E", 1642967788, "bobo", "E", 1642967856, "bobo", "P", 1642967886, "bobo", "P", 1642968013, "bobo", "P", 1642968171, "bobo", "P", 1642968373, "bobo", "E", 1642968551, "bobo", "E", 1642968589, "bobo", "E", 1642968647, "bobo", "E", 1642969355, "bobo", "E", 1642969399, "bobo", "E", 1642969452, "bobo", "P", 1642969515, "bobo", "P", 1642969569, "bobo", "P", 1642969581, "bobo", "P", 1642969646, "bobo", "P", 1642969702, "bobo", "P", 1642969869, "bobo", "P", 1642969956, "bobo", "P", 1642969992, "bobo", "P", 1642970050, "bobo", "P", 1642970063, "bobo", "P", 1642970089, "bobo", "P", 1642970126, "bobo", "P", 1642970305, "bobo", "P", 1642970309, "bobo", "P" \})
+      </Core:Property>
+    </Core:Properties>
+    <Notes:Notes/>
+  </Socials:Verb>
+</object>

--- a/skoot/data/vault/SID/UserAPI/Note.xml
+++ b/skoot/data/vault/SID/UserAPI/Note.xml
@@ -1,0 +1,13 @@
+<object clone="/usr/SID/obj/sidnode" owner="SID">
+  <SID:Element ns="UserAPI" tag="Note" recpoint="false" transient="false">
+    <SID:Children/>
+    <SID:Attributes>
+      <SID:Attribute id="note" atype="lpc_str" areadonly="true"/>
+    </SID:Attributes>
+    <SID:Iterator var="note" call="query_notes"/>
+    <SID:Callbacks>
+      <SID:Callback call="addnote(CONTENT)"/>
+      <SID:Callback call="killnote(CONTENT)"/>
+    </SID:Callbacks>
+  </SID:Element>
+</object>

--- a/skoot/data/vault/SID/UserAPI/Note.xml
+++ b/skoot/data/vault/SID/UserAPI/Note.xml
@@ -3,7 +3,7 @@
     <SID:Children/>
     <SID:Attributes>
       <SID:Attribute id="note" atype="lpc_str" areadonly="true" aquery="query_note_note(notes)"/>
-      <SID:Attribute id="date" atype="lpc_str" areadonly="true" aquery="query_note_date(notes)"/>
+      <SID:Attribute id="date" atype="lpc_int" areadonly="true" aquery="query_note_date(notes)"/>
       <SID:Attribute id="filed_by" atype="lpc_str" areadonly="true" aquery="query_note_body(notes)"/>
     </SID:Attributes>
     <SID:Iterator var="notes" call="query_notes"/>

--- a/skoot/data/vault/SID/UserAPI/Note.xml
+++ b/skoot/data/vault/SID/UserAPI/Note.xml
@@ -2,9 +2,11 @@
   <SID:Element ns="UserAPI" tag="Note" recpoint="false" transient="false">
     <SID:Children/>
     <SID:Attributes>
-      <SID:Attribute id="note" atype="lpc_str" areadonly="true"/>
+      <SID:Attribute id="note" atype="lpc_str" areadonly="true" aquery="query_note_note(notes)"/>
+      <SID:Attribute id="date" atype="lpc_str" areadonly="true" aquery="query_note_date(notes)"/>
+      <SID:Attribute id="filed_by" atype="lpc_str" areadonly="true" aquery="query_note_body(notes)"/>
     </SID:Attributes>
-    <SID:Iterator var="note" call="query_notes"/>
+    <SID:Iterator var="notes" call="query_notes"/>
     <SID:Callbacks>
       <SID:Callback call="addnote(CONTENT)"/>
       <SID:Callback call="killnote(CONTENT)"/>

--- a/skoot/data/vault/SID/UserAPI/Notes.xml
+++ b/skoot/data/vault/SID/UserAPI/Notes.xml
@@ -1,11 +1,10 @@
 <object clone="/usr/SID/obj/sidnode" owner="SID">
-  <SID:Element type="lpc_obj" ns="UserAPI" tag="Notes" recpoint="false" transient="true" query="query_notes">
-    <SID:Children/>
+  <SID:Element ns="UserAPI" tag="Notes" recpoint="true" transient="false">
+    <SID:Children>
+      <SID:Child node="OBJ(SID:UserAPI:Note)"/>
+    </SID:Children>
     <SID:Attributes/>
     <SID:Iterator/>
-    <SID:Callbacks>
-      <SID:Callback call="addnote(CONTENT)"/>
-      <SID:Callback call="killnote(CONTENT)"/>
-    </SID:Callbacks>
+    <SID:Callbacks/>
   </SID:Element>
 </object>

--- a/skoot/data/vault/SID/UserAPI/Notes.xml
+++ b/skoot/data/vault/SID/UserAPI/Notes.xml
@@ -1,0 +1,11 @@
+<object clone="/usr/SID/obj/sidnode" owner="sarah">
+  <SID:Element type="lpc_str" ns="UserAPI" tag="Notes" recpoint="false" transient="true" query="query_notes">
+    <SID:Children/>
+    <SID:Attributes/>
+    <SID:Iterator/>
+    <SID:Callbacks>
+      <SID:Callback call="addnote(CONTENT)"/>
+      <SID:Callback call="killnote(CONTENT)"/>
+    </SID:Callbacks>
+  </SID:Element>
+</object>

--- a/skoot/data/vault/SID/UserAPI/Notes.xml
+++ b/skoot/data/vault/SID/UserAPI/Notes.xml
@@ -1,5 +1,5 @@
-<object clone="/usr/SID/obj/sidnode" owner="sarah">
-  <SID:Element type="lpc_str" ns="UserAPI" tag="Notes" recpoint="false" transient="true" query="query_notes">
+<object clone="/usr/SID/obj/sidnode" owner="SID">
+  <SID:Element type="lpc_obj" ns="UserAPI" tag="Notes" recpoint="false" transient="true" query="query_notes">
     <SID:Children/>
     <SID:Attributes/>
     <SID:Iterator/>

--- a/skoot/data/vault/SID/UserAPI/UDat.xml
+++ b/skoot/data/vault/SID/UserAPI/UDat.xml
@@ -4,6 +4,7 @@
       <SID:Child node="OBJ(SID:Core:Properties)"/>
       <SID:Child node="OBJ(SID:UserAPI:Suspended)"/>
       <SID:Child node="OBJ(SID:UserAPI:Bodies)"/>
+      <SID:Child node="OBJ(SID:UserAPI:Notes)"/>
     </SID:Children>
     <SID:Attributes/>
     <SID:Iterator/>

--- a/skoot/usr/UserAPI/obj/udat.c
+++ b/skoot/usr/UserAPI/obj/udat.c
@@ -563,7 +563,7 @@ addnote(string note, string body, int timestamp) {
 
 void
 killnote() {
-    notes = notes[.. sizeof(notes)-1];
+    notes = notes[.. sizeof(notes)-2];
 }
 
 mixed

--- a/skoot/usr/UserAPI/obj/udat.c
+++ b/skoot/usr/UserAPI/obj/udat.c
@@ -576,7 +576,7 @@ query_note_note(mixed *notes) {
     return notes[0];
 }
 
-string
+int
 query_note_date(mixed *notes) {
     return notes[1];
 }

--- a/skoot/usr/UserAPI/obj/udat.c
+++ b/skoot/usr/UserAPI/obj/udat.c
@@ -578,12 +578,12 @@ query_note_note(mixed *notes) {
 
 int
 query_note_date(mixed *notes) {
-    return notes[1];
+    return notes[2];
 }
 
 string
 query_note_body(mixed *notes) {
-    return notes[2];
+    return notes[1];
 }
 
 void

--- a/skoot/usr/UserAPI/obj/udat.c
+++ b/skoot/usr/UserAPI/obj/udat.c
@@ -44,6 +44,8 @@ mapping last_ip_numbers;        /* Keep track of last ipnrs, per category */
 
 string  suspended;
 
+mixed *notes;
+
 mapping logged_in;		/* Keep track of counters and timestamps. */
 mapping theatre_id;		/* Keep track of initial theatre-ids. */
 
@@ -67,6 +69,8 @@ void create(int clone) {
 
       logged_in = ([ ]);
       theatre_id = ([ ]);
+       
+      notes = ({ });
    }
 }
 
@@ -550,6 +554,21 @@ query_last_event(string ipentry)
    }
    /* Should not get here, assuming the function was called appropriately. */
    return 0;
+}
+
+void
+addnote(string note, string body, int timestamp) {
+    notes += ({ ({ note, body, timestamp }) })
+}
+
+void
+killnote() {
+    notes = notes[.. sizeof(notes)-1];
+}
+
+mixed
+*query_notes() {
+    return notes;
 }
 
 void

--- a/skoot/usr/UserAPI/obj/udat.c
+++ b/skoot/usr/UserAPI/obj/udat.c
@@ -578,7 +578,7 @@ query_note_note(mixed *notes) {
 
 string
 query_note_date(mixed *notes) {
-    return itoa(notes[1]);
+    return notes[1];
 }
 
 string

--- a/skoot/usr/UserAPI/obj/udat.c
+++ b/skoot/usr/UserAPI/obj/udat.c
@@ -571,6 +571,21 @@ mixed
     return notes;
 }
 
+string
+query_note_note(mixed *notes) {
+    return notes[0];
+}
+
+string
+query_note_date(mixed *notes) {
+    return itoa(notes[1]);
+}
+
+string
+query_note_body(mixed *notes) {
+    return notes[2];
+}
+
 void
 set_suspended(string reason)
 {

--- a/skoot/usr/UserAPI/obj/udat.c
+++ b/skoot/usr/UserAPI/obj/udat.c
@@ -558,7 +558,7 @@ query_last_event(string ipentry)
 
 void
 addnote(string note, string body, int timestamp) {
-    notes += ({ ({ note, body, timestamp }) })
+    notes += ({ ({ note, body, timestamp }) });
 }
 
 void

--- a/skoot/usr/UserAPI/sys/udatd.c
+++ b/skoot/usr/UserAPI/sys/udatd.c
@@ -608,7 +608,8 @@ call_method(string method, mapping args) {
      addnote(args["user"], args["note"], args["body"], args["timestamp"], args["head"], args["desc"]);
      return nil;
    case "killnote":
-     return killnote(args["user"], args["head"], args["desc"]);
+     killnote(args["user"], args["head"], args["desc"]);
+     return nil;
    case "notes":
      return notes(args["user"]);
    default:

--- a/skoot/usr/UserAPI/sys/udatd.c
+++ b/skoot/usr/UserAPI/sys/udatd.c
@@ -605,7 +605,7 @@ call_method(string method, mapping args) {
    case "query_suspended":
      return query_suspended(args["user"]);
    case "addnote":
-     addnotes(args["user"], args["note"], args["body"], args["timestamp"], args["head"], args["desc"]);
+     addnote(args["user"], args["note"], args["body"], args["timestamp"], args["head"], args["desc"]);
      return nil;
    case "killnote":
      return killnote(args["user"], args["head"], args["desc"]);

--- a/skoot/usr/UserAPI/sys/udatd.c
+++ b/skoot/usr/UserAPI/sys/udatd.c
@@ -167,7 +167,7 @@ void killnote(string user, string head, SAM desc) {
     LOGD->add_entry("Notes Log", head, desc);
 }
 
-void notes(string user) {
+string *notes(string user) {
     object udat;
     
     udat = udats_arr[user[0]][user];

--- a/skoot/usr/UserAPI/sys/udatd.c
+++ b/skoot/usr/UserAPI/sys/udatd.c
@@ -143,6 +143,41 @@ mixed query_udats() {
 
 /* body/name stuff */
 
+void addnote(string user, string note, string body, int timestamp, string head, SAM desc) {
+    object udat;
+    
+    udat = udats_arr[user[0]][user];
+    if(!udat) {
+        error("unknown user");
+    }
+    
+    udat->addnote(note, body, timestamp);
+    
+    LOGD->add_entry("Notes Log", head, desc);
+}
+
+void killnote(string user, string head, SAM desc) {
+    object udat;
+    
+    udat = udats_arr[user[0]][user];
+    if(!udat) {
+        error("unknown user");
+    }
+    
+    LOGD->add_entry("Notes Log", head, desc);
+}
+
+void notes(string user) {
+    object udat;
+    
+    udat = udats_arr[user[0]][user];
+    if(!udat) {
+        error("unknown user");
+    }
+    
+    return udat->query_notes();
+}
+
 void set_suspended(string reason, string user, string head, SAM desc) {
    object udat;
 
@@ -154,9 +189,6 @@ void set_suspended(string reason, string user, string head, SAM desc) {
    udat->set_suspended(reason);
    
    LOGD->add_entry("Suspend Log", head, desc);
-   
-   
-   
 }
 
 string query_suspended(string user) {
@@ -471,6 +503,9 @@ int query_method(string method) {
    case "udat_list":
    case "set_suspended":
    case "query_suspended":
+   case "addnote":
+   case "killnote":
+   case "notes":
       return TRUE;
    default:
    return FALSE;
@@ -569,6 +604,13 @@ call_method(string method, mapping args) {
      return nil;
    case "query_suspended":
      return query_suspended(args["user"]);
+   case "addnote":
+     addnotes(args["user"], args["note"], args["body"], args["timestamp"], args["head"], args["desc"]);
+     return nil;
+   case "killnote":
+     return killnote(args["user"], args["head"], args["desc"]);
+   case "notes":
+     return notes(args["user"]);
    default:
       return nil;
    }


### PR DESCRIPTION
Rewrote the notes system in Merry. The following Merry commands have been added:

-   Neoct:Staff:Guides:Verbs:!killnote
-   Neoct:Staff:Guides:Verbs:!notes
-   Neoct:Staff:Guides:Verbs:!addnote
-   Neoct:Staff:Verbs:+addnote
-   Neoct:Staff:Verbs:+killnote
-   Neoct:Staff:Verbs:+notes

Since notes are user account specific, the information will be stored in the account's udat. I updated the following DGD files to handling storing and retrieving this information. Adding/deleting notes will also be logged at the DGD level:

- skoot/usr/UserAPI/sys/udatd.c
- skoot/usr/UserAPI/sys/udat.c

Finally, in order for notes to be visible in Tree of Woe, I updated the UserAPI/UDat node and added these SID objects:

- skoot/data/vault/SID/UserAPI/Notes.xml
- skoot/data/vault/SID/UserAPI/Note.xml
- 