### PR TITLE
Sanity check DGD configuration before booting or rebooting

### DIFF
--- a/skoot/usr/System/initd.c
+++ b/skoot/usr/System/initd.c
@@ -45,11 +45,30 @@ string jitsi_host;
 
 void get_instance();
 
+private
+void config_check() {
+   mixed *status;
+
+   status = status();
+
+   if (status[ST_STRSIZE] < 1048576) {
+      shutdown();
+      error("Config error: max string size too small.  Please rebuild DGD after amending config.h");
+   }
+
+   if (status[ST_ARRAYSIZE] < 16384) {
+      shutdown();
+      error("Config error: max array size too small (min 16384).  Please amend skotos.dgd");
+   }
+}
+
 static
 void create() {
    access::create();
    rsrc::create();
    tls::create();
+
+   config_check();
 
    /* give System full access */
    add_user("System");

--- a/skoot/usr/System/initd.c
+++ b/skoot/usr/System/initd.c
@@ -201,6 +201,8 @@ void prepare_reboot() {
 
 void reboot() {
    if (previous_program() == DRIVER) {
+      config_check();
+
       if (dump) {
 	 remove_call_out(dump);
       }


### PR DESCRIPTION
I noticed some runtime errors during the initialization phase.

Since SkotOS was designed to work with a 32 bit string size from even before its open source release it seems prudent to sanity check DGD's configuration before we even attempt to load anything.

Each commit addresses two separate cases of the same issue.

The first one checks during initial cold boot.

The second checks during a reboot.

Both checks are intended to protect runtime information from being contaminated by a faulty configuration setting.