### PR TITLE
Update for DGD change, tighter aggregate typechecking.

### DIFF
--- a/skoot/data/vault/CharGen/StartStoryFrame.xml
+++ b/skoot/data/vault/CharGen/StartStoryFrame.xml
@@ -856,7 +856,7 @@ would be returned as:
 string Head;
 string Tail;
 string Property;
-string *Properties_arr;
+string **Properties_arr;
 
 Properties_arr = (\{\});
 if(!\$choices) return Properties_arr;

--- a/skoot/data/vault/CharGen/StartStoryFrame_backup.xml
+++ b/skoot/data/vault/CharGen/StartStoryFrame_backup.xml
@@ -1211,7 +1211,7 @@ would be returned as:
 string Head;
 string Tail;
 string Property;
-string *Properties_arr;
+string **Properties_arr;
 
 Properties_arr = (\{\});
 if(!\$choices) return Properties_arr;

--- a/skoot/data/vault/Lib/Assist/lib/assistlibs.xml
+++ b/skoot/data/vault/Lib/Assist/lib/assistlibs.xml
@@ -2279,7 +2279,7 @@ return FALSE;
 
 */
 
-string *str, *long, *short;
+string **str, *long, *short;
 mapping flags;
 
 
@@ -5282,7 +5282,7 @@ EmitTo(\$actor, PRE(("Stats Started: " + spaces(20))[..17] + ctime(\$started) + 
 
 */
 
-string header, *tableassist, *tableplayer;
+string header, **tableassist, **tableplayer;
 int i;
 
 \$general = copy(\$data."mapping:general:statistics");

--- a/skoot/data/vault/Lib/ascii.xml
+++ b/skoot/data/vault/Lib/ascii.xml
@@ -268,7 +268,7 @@ constant DBOOL = (\{ "yes", "no" \});
 constant VALUE = typeof(data[\$columns[c]]) == T_STRING ? data[\$columns[c]] : Str(data[\$columns[c]]);
 
 mapping data, types, bools;
-string *result, *row, *col;
+string **result, *row, *col;
 int i, ix, c, cx;
 
 /* Store header data and secure types and bools. */

--- a/skoot/data/vault/Neoct/OOC/Verbs/%40adverb.xml
+++ b/skoot/data/vault/Neoct/OOC/Verbs/%40adverb.xml
@@ -7,7 +7,7 @@
       <Core:Property property="merry:global:command">
          X[M] /* Lists all adverbs that match supplied term */
 
-string emit, match, first, *adverbs, *arr;
+string emit, match, first, *adverbs, **arr;
 int sz_i, n, i, rows;
 
 \{

--- a/skoot/data/vault/Neoct/OOC/Verbs/%40verb.xml
+++ b/skoot/data/vault/Neoct/OOC/Verbs/%40verb.xml
@@ -7,7 +7,7 @@
       <Core:Property property="merry:global:command">
          X[M] /* Lists all verbs that match supplied term */
 
-string emit, match, first, *verbs, *arr;
+string emit, match, first, *verbs, **arr;
 int sz_i, n, i, rows;
 
 \{

--- a/skoot/data/vault/Neoct/Staff/Chats/Filters/NewlieChat.xml
+++ b/skoot/data/vault/Neoct/Staff/Chats/Filters/NewlieChat.xml
@@ -69,7 +69,7 @@ return FALSE;
 int     REVISION, i, sz;
 mapping auth_list;
 object  *list;
-string  *result;
+string  **result;
 
 REVISION = \$\{Lib:chatlib\}.revision;
 

--- a/skoot/data/vault/Neoct/Staff/Verbs/%2Binventory.xml
+++ b/skoot/data/vault/Neoct/Staff/Verbs/%2Binventory.xml
@@ -8,7 +8,7 @@
          X[M] /* Merryized version of +inventory */
 
 object obj, *inv, item;
-string emit, *arr, *data;
+string emit, *arr, **data;
 int i;
 
 \{

--- a/skoot/data/vault/SLib/staff.xml
+++ b/skoot/data/vault/SLib/staff.xml
@@ -40,7 +40,7 @@
     4: Seperate Story* staff from player list
 */
 
-string bodystr, bodyname, output, words, *indices, *arr, stridle;
+string bodystr, bodyname, output, words, *indices, **arr, stridle;
 int i, sz_i, sz, n, rows, idlelen;
 object *bodylist, body;
 mapping whofour, staff, idle, players, hidden, hiddenidle, away;


### PR DESCRIPTION
In commit https://github.com/dworkin/dgd/commit/3ad6ae78f885e3ad357edd430350d33320437001, DGD started constructing types other than `mixed *` for array aggregates. This patch enables SkotOS to properly boot again after those changes.